### PR TITLE
fix: Lagrange.OneBot 的 pathMap 错误

### DIFF
--- a/src/assets/pathMap/Lagrange.OneBot.json
+++ b/src/assets/pathMap/Lagrange.OneBot.json
@@ -16,9 +16,9 @@
 
             "class_id": "/group_id",
             "class_name": "/group_name",
-            "user_id": "/user_id",
-            "nickname": "/user_name",
-            "remark": "/user_remark"
+            "user_id": "/user_id",            
+            "nickname": "/username",
+            "remark": "/remark"
         }
     },
     "roaming_stamp": {


### PR DESCRIPTION
pathMap 错误，导致加载 user 的时候 nickname, remark 字段为 undefined，从而无法使用搜索功能