### PR TITLE
十月 / 十一月累计更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Stapxs QQ Lite 需要一个 QQ Bot 后端提供服务，你可以参考 [📖 �
 本仓库开启了 GitHub Pages, 所有向主分支提交的代码将会自动构建并发布。你可以直接访问 [🌎 这个页面](https://stapxs.github.io/Stapxs-QQ-Lite-2.0) 来使用已经构建并部署的页面。
 
 ### > 安装应用
-除了直接使用本仓库的构建页面，你也可以下载使用 electron 打包的功能**稍稍**更丰富的客户端版本，访问 [📦️ 这儿](https://github.com/Stapxs/Stapxs-QQ-Lite-2.0/releases) 查看构建列表。
+除了直接使用本仓库的构建页面，你也可以下载使用 electron 打包的功能**稍稍**更丰富的客户端版本，访问 [📦️ 这儿](https://github.com/Stapxs/Stapxs-QQ-Lite-2.0/releases) 查看版本发布列表。
 
 当然你也可以使用包管理来安装它，使用包管理安装将会更便于更新 Stapxs QQ Lite 而不用每次都从 Github 上手动更新，访问 [💬 这儿](https://github.com/Stapxs/Stapxs-QQ-Lite-2.0/issues/99) 来查看目前支持的包管理。
 
@@ -70,8 +70,16 @@ Stapxs QQ Lite 需要一个 QQ Bot 后端提供服务，你可以参考 [📖 �
 - 如果有什么奇奇怪怪的问题, 欢迎发起 [issue](<https://github.com/Stapxs/Stapxs-QQ-Lite/issues>) 询问! 如果有什么 BUG 和优化建议也可以哦! 
 
 ## 📦️ 构建应用
+为了规范对其他仓库的引用，Stapxs QQ Lite 2.0 仓库含有一些子模块，这意味着你需要在克隆仓库的时候包含子模块：
+~~~bash
+git clone https://github.com/Stapxs/Stapxs-QQ-Lite-2.0 --recursive
+~~~
+如果你已经克隆了仓库，也可以使用这个来补全子模块：
+~~~bash
+git submodule update --init
+~~~
 ### > 构建 Web 页面
-Stapxs QQ Lite 2.0 是一个基于 Vue 的单页应用，这意味着如果你想自行部署到网页服务需要进行构建。
+Stapxs QQ Lite 2.0 是一个基于 Vue 的单页应用，这意味着如果你想自行部署到网页服务需要进行构建。当然你同样可以前往 [这儿](https://github.com/Stapxs/Stapxs-QQ-Lite-2.0/releases) 来下载预构建好的根目录文件包。
 
 注意。在正式构建前，如果你的网站运作目录并不在根域名下，你需要修改（或增加）项目根目录下 `vue.config.js` 内导出的 `publicPath` 字段的值，它代表着最终你会运行在的目录，比如它在现在是 `/Stapxs-QQ-Lite-2.0/`；如果你本来就运行在根目录下，可以直接删去它。
 
@@ -112,5 +120,5 @@ yarn electron:build --linux
 ## 🎉 鸣谢
 感谢这些小伙伴们在开发和文本中提供的支持 ——
 
-<a href="https://github.com/Logic-Accepted"><img  src="https://avatars.githubusercontent.com/u/36406453?s=48&v=4"></a>
-<a href="https://github.com/doodlehuang"><img  src="https://avatars.githubusercontent.com/u/25525621?s=48&v=4"></a>
+<a href="https://github.com/Logic-Accepted"><img src="https://avatars.githubusercontent.com/u/36406453?s=48&v=4"></a>
+<a href="https://github.com/doodlehuang"><img src="https://avatars.githubusercontent.com/u/25525621?s=48&v=4"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stapxs-qq-lite",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "private": false,
   "author": "Stapx Steve [林槐]",
   "description": "一个兼容 OneBot 的非官方网页版 QQ 客户端，使用 Vue 重制的全新版本。",
@@ -47,7 +47,7 @@
     "vue-clipboard2": "^0.3.3",
     "vue-i18n": "^9.2.2",
     "vue-prism-editor": "^2.0.0-alpha.2",
-    "vue3-bcui": "^0.2.3",
+    "vue3-bcui": "^0.2.6",
     "vue3-danmaku": "^1.6.0",
     "vue3-infinite-scroll-better": "^2.2.0",
     "xss": "^1.0.14"

--- a/src/App.vue
+++ b/src/App.vue
@@ -269,7 +269,9 @@ export default defineComponent({
          */
         changeTab (name: string, view: string, show: boolean) {
             // UM：发送页面路由分析
-            Umami.trackPageView('/' + view)
+            if (!Option.get('close_ga') && process.env.NODE_ENV == 'production') {
+                Umami.trackPageView('/' + view)
+            }
             this.tags.showChat = show
             this.tags.page = view
         },
@@ -534,7 +536,9 @@ export default defineComponent({
                 }
                 Umami.initialize(config)
             } else if (process.env.NODE_ENV == 'development') {
-                logger.debug('由于运行在调试模式下，分析组件并未加载 ……')
+                logger.debug('由于运行在调试模式下，分析组件并未初始化 ……')
+            } else if (Option.get('close_ga')) {
+                logger.debug('统计功能已被关闭，分析组件并未初始化 ……')
             }
             App.checkUpdate()                // 检查更新
             App.checkOpenTimes()             // 检查打开次数

--- a/src/assets/css/append/append_new.css
+++ b/src/assets/css/append/append_new.css
@@ -184,9 +184,6 @@
 .face-pan {
     border: 1px solid var(--color-card-2);
 }
-.store-face-list > div {
-    width: calc(20% - 10px) !important;
-}
 .face-pan div.tab-main {
     margin-top: 10px !important;
 }
@@ -594,9 +591,6 @@
     margin: 8px;
     height: 19px;
     width: 19px;
-}
-.store-face-list {
-    height: calc(300px - 90px) !important;
 }
 
 .face-stickers {

--- a/src/assets/css/append/append_new.css
+++ b/src/assets/css/append/append_new.css
@@ -566,7 +566,7 @@
     max-width: 30%;
 }
 .app-msg > div > a {
-    font-size: 0.87rem;
+    font-size: 0.75rem;
 }
 .app-msg > div > div:first-child > svg {
     margin-top: 3px;

--- a/src/assets/css/chat.css
+++ b/src/assets/css/chat.css
@@ -1297,6 +1297,60 @@ input {
     flex: 1;
 }
 
+.select-tag {
+    background: var(--color-card-1);
+    justify-content: space-evenly;
+    margin: 0 20px 10px 20px;
+    transition: all .3s;
+    align-items: center;
+    flex-direction: row;
+    border-radius: 7px;
+    overflow: hidden;
+    display: flex;
+    height: 0;
+}
+.select-tag.show {
+    margin: 0 20px 10px 20px;
+    margin-top: 20px;
+    padding: 15px 10px;
+    height: auto;
+}
+.select-tag > div {
+    flex-direction: column;
+    align-items: center;
+    display: flex;
+}
+.select-tag > div > svg,
+.select-tag > div > span:first-child {
+    background: var(--color-card-2);
+    color: var(--color-font-1);
+    border-radius: 100%;
+    cursor: pointer;
+    height: 0.8rem;
+    width: 0.8rem;
+    padding: 15px;
+}
+.select-tag > div > span:first-child {
+    border: 1px solid var(--color-main);
+    text-align: center;
+    font-weight: bold;
+    color: var(--color-font);
+    font-size: calc(0.8rem + 3px);
+    padding: 12px 15px 18px 15px;
+}
+.select-tag > div > span {
+    color: var(--color-font-2);
+    font-size: 0.75rem;
+    margin-top: 5px;
+}
+
+.msg-select-tag {
+
+}
+msg-select-tag > svg {
+    
+}
+
 .replay-tag {
     background: var(--color-card-1);
     margin: 0 20px -10px 20px;

--- a/src/assets/css/msg.css
+++ b/src/assets/css/msg.css
@@ -14,6 +14,9 @@
     flex-wrap: wrap;
     transition: opacity 0.3s;
 }
+.message.selected {
+    background: #00000008;
+}
 .message.forward {
     border: 2px solid var(--color-card-2);
     width: calc(100% - 45px);
@@ -81,7 +84,7 @@
 .message-body > span {
     font-size: 0.7rem;
     background: var(--color-main);
-    color: #fff;
+    color: var(--color-font-r);
     border-radius: 10px;
     padding: 1px 4px;
 }

--- a/src/assets/l10n/en-US.po
+++ b/src/assets/l10n/en-US.po
@@ -1062,18 +1062,6 @@ msgstr ""
 msgid "下载更新…"
 msgstr ""
 
-#: src/pages/Chat.vue:336
-msgid "收藏商城表情"
-msgstr ""
-
-#: src/pages/Chat.vue:1027
-msgid "表情已被收藏"
-msgstr ""
-
-#: src/pages/Chat.vue:1031
-msgid "表情收藏成功"
-msgstr ""
-
 #: src/function/utils/appUtil.ts:69
 msgid "请不要在内嵌页面中输入敏感信息，内嵌页面并不安全。"
 msgstr ""

--- a/src/assets/l10n/en-US.po
+++ b/src/assets/l10n/en-US.po
@@ -503,10 +503,6 @@ msgstr "{readNum} read | {isRead}"
 msgid "公告"
 msgstr "Announcements"
 
-#: src/pages/options/OptDev.vue:139
-msgid "页面测试"
-msgstr "UI test"
-
 #: src/pages/options/OptDev.vue:140
 msgid "让我康康 ~"
 msgstr "Show test interfaces"
@@ -1442,4 +1438,12 @@ msgstr ""
 
 #: src/function/utils/msgUtil.ts:231
 msgid "视频"
+msgstr ""
+
+#: src/pages/Chat.vue:159
+msgid "合并转发"
+msgstr ""
+
+#: src/pages/Chat.vue:163
+msgid "截图"
 msgstr ""

--- a/src/assets/l10n/zh-CN.po
+++ b/src/assets/l10n/zh-CN.po
@@ -504,10 +504,6 @@ msgstr ""
 msgid "公告"
 msgstr ""
 
-#: src/pages/options/OptDev.vue:139
-msgid "页面测试"
-msgstr ""
-
 #: src/pages/options/OptDev.vue:140
 msgid "让我康康 ~"
 msgstr ""
@@ -1439,4 +1435,12 @@ msgstr ""
 
 #: src/function/utils/msgUtil.ts:231
 msgid "视频"
+msgstr ""
+
+#: src/pages/Chat.vue:159
+msgid "合并转发"
+msgstr ""
+
+#: src/pages/Chat.vue:163
+msgid "截图"
 msgstr ""

--- a/src/assets/l10n/zh-CN.po
+++ b/src/assets/l10n/zh-CN.po
@@ -1063,18 +1063,6 @@ msgstr ""
 msgid "下载更新…"
 msgstr ""
 
-#: src/pages/Chat.vue:336
-msgid "收藏商城表情"
-msgstr ""
-
-#: src/pages/Chat.vue:1027
-msgid "表情已被收藏"
-msgstr ""
-
-#: src/pages/Chat.vue:1031
-msgid "表情收藏成功"
-msgstr ""
-
 #: src/function/utils/appUtil.ts:69
 msgid "请不要在内嵌页面中输入敏感信息，内嵌页面并不安全。"
 msgstr ""

--- a/src/assets/l10n/zh-TW.po
+++ b/src/assets/l10n/zh-TW.po
@@ -1063,18 +1063,6 @@ msgstr ""
 msgid "下载更新…"
 msgstr ""
 
-#: src/pages/Chat.vue:336
-msgid "收藏商城表情"
-msgstr ""
-
-#: src/pages/Chat.vue:1027
-msgid "表情已被收藏"
-msgstr ""
-
-#: src/pages/Chat.vue:1031
-msgid "表情收藏成功"
-msgstr ""
-
 #: src/function/utils/appUtil.ts:69
 msgid "请不要在内嵌页面中输入敏感信息，内嵌页面并不安全。"
 msgstr ""

--- a/src/assets/l10n/zh-TW.po
+++ b/src/assets/l10n/zh-TW.po
@@ -504,10 +504,6 @@ msgstr "{readNum} 人已讀 | {isRead}"
 msgid "公告"
 msgstr "公告"
 
-#: src/pages/options/OptDev.vue:139
-msgid "页面测试"
-msgstr "頁面測試"
-
 #: src/pages/options/OptDev.vue:140
 msgid "让我康康 ~"
 msgstr "「讓我看看！！！」"
@@ -1439,4 +1435,12 @@ msgstr ""
 
 #: src/function/utils/msgUtil.ts:231
 msgid "视频"
+msgstr ""
+
+#: src/pages/Chat.vue:159
+msgid "合并转发"
+msgstr ""
+
+#: src/pages/Chat.vue:163
+msgid "截图"
 msgstr ""

--- a/src/assets/l10n/zh-YUE.po
+++ b/src/assets/l10n/zh-YUE.po
@@ -504,10 +504,6 @@ msgstr "{readNum} 人已讀 | {isRead}"
 msgid "公告"
 msgstr "公告"
 
-#: src/pages/options/OptDev.vue:139
-msgid "页面测试"
-msgstr "頁面測試"
-
 #: src/pages/options/OptDev.vue:140
 msgid "让我康康 ~"
 msgstr "點解我要 OT 啊？"
@@ -1439,4 +1435,12 @@ msgstr ""
 
 #: src/function/utils/msgUtil.ts:231
 msgid "视频"
+msgstr ""
+
+#: src/pages/Chat.vue:159
+msgid "合并转发"
+msgstr ""
+
+#: src/pages/Chat.vue:163
+msgid "截图"
 msgstr ""

--- a/src/assets/l10n/zh-YUE.po
+++ b/src/assets/l10n/zh-YUE.po
@@ -1063,18 +1063,6 @@ msgstr ""
 msgid "下载更新…"
 msgstr ""
 
-#: src/pages/Chat.vue:336
-msgid "收藏商城表情"
-msgstr ""
-
-#: src/pages/Chat.vue:1027
-msgid "表情已被收藏"
-msgstr ""
-
-#: src/pages/Chat.vue:1031
-msgid "表情收藏成功"
-msgstr ""
-
 #: src/function/utils/appUtil.ts:69
 msgid "请不要在内嵌页面中输入敏感信息，内嵌页面并不安全。"
 msgstr ""

--- a/src/assets/pathMap/NapCat.Onebot.yaml
+++ b/src/assets/pathMap/NapCat.Onebot.yaml
@@ -147,3 +147,7 @@ recent_contact:
         time: /msgTime
         chat_type: /chatType
         name: /peerName
+# 戳一戳
+poke:
+    name: group_poke
+    private_name: friend_poke

--- a/src/assets/pathMap/NapCat.Onebot.yaml
+++ b/src/assets/pathMap/NapCat.Onebot.yaml
@@ -106,16 +106,16 @@ group_notices:
 # 获取群精华消息
 group_essence:
     name: get_essence_msg_list
-    source: $.data.msg_list[*]
+    source: $.data[*]
     list:
-        sender_uin: /sender_uin
+        sender_uin: /sender_id
         sender_nick: /sender_nick
-        sender_time: /sender_time
-        msg_content: /msg_content
-        add_digest_uin: /add_digest_uin
-        add_digest_nick: /add_digest_nick
-        add_digest_time: /add_digest_time
-    is_end: $.data.is_end
+        sender_time: /operator_time
+        msg_content: /content
+        add_digest_uin: /operator_id
+        add_digest_nick: /operator_nick
+        add_digest_time: /operator_time
+    is_end: null
 # 获取群成员信息
 group_member_info:
     name: get_group_member_info

--- a/src/components/AboutPan.vue
+++ b/src/components/AboutPan.vue
@@ -127,12 +127,11 @@
 </template>
 
 <script lang="ts">
-import Umami from '@stapxs/umami-logger-typescript'
 import DepPan from './DepPan.vue'
 import packageInfo from '../../package.json'
 
 import { defineComponent } from 'vue'
-import { openLink } from '@/function/utils/appUtil'
+import { openLink, sendStatEvent } from '@/function/utils/appUtil'
 import { ContributorElem } from '@/function/elements/system'
 
 import { runtimeData } from '@/function/msg'
@@ -164,14 +163,12 @@ export default defineComponent({
 
         goGithub() {
             openLink('https://github.com/Stapxs/Stapxs-QQ-Lite-2.0')
-            // UM：统计点击事件
-            Umami.trackEvent('click_statistics', { name: 'visit_github' })
+            sendStatEvent('click_statistics', { name: 'visit_github' })
         },
 
         goBlog() {
             openLink('https://blog.stapxs.cn/About.html')
-            // UM：统计点击事件
-            Umami.trackEvent('click_statistics', { name: 'visit_blog' })
+            sendStatEvent('click_statistics', { name: 'visit_blog' })
         }
     },
     mounted() {

--- a/src/components/FacePan.vue
+++ b/src/components/FacePan.vue
@@ -28,17 +28,6 @@
                     </div>
                 </div>
             </div>
-            <div icon="fa-solid fa-store">
-                <div class="store-face-list">
-                    <div v-for="face in storeFace" :key="face.emoji_id">
-                        <font-awesome-icon @click="removeMface(face)" :icon="['fas', 'xmark']" />
-                        <img loading="lazy"
-                            :src="face.url"
-                            :title="face.summary"
-                            @click="addMface(face)">
-                    </div>
-                </div>
-            </div>
         </BcTab>
     </div>
 </template>
@@ -66,7 +55,6 @@ export default defineComponent({
             Option: Option,
             runtimeData: runtimeData,
             baseFaceMax: 348,
-            storeFace: [] as {[type: string]: string}[],
             stickerPage: 1
         }
     },
@@ -78,21 +66,7 @@ export default defineComponent({
             this.addSpecialMsg({ type: 'face', id: id }, true)
         },
         addImgFace(url: string) {
-            this.addSpecialMsg({ type: 'image', file: url, cache: true, asface: true }, true)
-        },
-        addMface(data: any) {
-            this.addSpecialMsg(data, true)
-        },
-
-        getStoreFaceList() {
-            this.storeFace = Option.get('store_face') ?? []
-        },
-        removeMface(data: any) {
-            const index = this.storeFace.findIndex((face) => face.emoji_id === data.emoji_id)
-            if (index !== -1) {
-                this.storeFace.splice(index, 1)
-                Option.save('store_face', this.storeFace)
-            }
+            this.addSpecialMsg({ type: 'image', file: url, subType: 1 }, true)
         },
 
         stickersScroll(e: Event) {
@@ -123,57 +97,6 @@ export default defineComponent({
                 Connector.send(runtimeData.jsonMap.roaming_stamp.name, {}, 'getRoamingStamp')
             }
         }
-        this.getStoreFaceList()
-        // 监听表情商店列表
-        this.$watch(() => runtimeData.sysConfig.store_face.length, () => {
-            this.getStoreFaceList()
-        })
     }
 })
 </script>
-<style scoped>
-.store-face-list {
-    display: flex;
-    width: 100%;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    justify-content: center;
-    height: calc(300px - 120px);
-    overflow-y: scroll;
-}
-.store-face-list > div {
-    cursor: pointer;
-    width: calc(25% - 15px);
-    margin-right: 10px;
-    margin-top: 5px;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-}
-.store-face-list > div:hover > svg {
-    opacity: 0.8;
-}
-.store-face-list svg {
-    width: 10px;
-    height: 10px;
-    color: var(--color-font);
-    margin-bottom: -12px;
-    margin-right: -5px;
-    opacity: 0;
-    z-index: 1;
-    background: var(--color-card-2);
-    border-radius: 100px;
-    padding: 5px;
-    backdrop-filter: blur(15px);
-    transition: opacity 0.3s;
-}
-.store-face-list svg:hover {
-    opacity: 1;
-}
-.store-face-list img {
-    border-radius: 7px;
-    width: 100%;
-    border: 2px solid var(--color-card-2);
-}
-</style>

--- a/src/components/MsgBody.vue
+++ b/src/components/MsgBody.vue
@@ -10,7 +10,7 @@
  -->
 
 <template>
-    <div :class="'message' + (type ? ' ' + type : '') + (data.revoke ? ' revoke' : '') + (isMe ? ' me': '')" :data-raw="getMsgRawTxt(data)"
+    <div :class="'message' + (type ? ' ' + type : '') + (data.revoke ? ' revoke' : '') + (isMe ? ' me': '') + (selected ? ' selected' : '')" :data-raw="getMsgRawTxt(data)"
         :id="'chat-' + data.message_id" :data-sender="data.sender.user_id" :data-time="data.time"
         @mouseleave="hiddenUserInfo">
         <img name="avatar" :src="'https://q1.qlogo.cn/g?b=qq&s=0&nk=' + data.sender.user_id" v-show="!isMe || type == 'merge'">
@@ -131,7 +131,6 @@
 import Option from '@/function/option'
 import CardMessage from './msg-component/CardMessage.vue'
 import app from '@/main'
-import Umami from '@stapxs/umami-logger-typescript'
 
 import { MsgBodyFuns as ViewFuns } from '@/function/model/msg-body'
 import { defineComponent } from 'vue'
@@ -140,12 +139,12 @@ import { runtimeData } from '@/function/msg'
 import { Logger, PopInfo, PopType } from '@/function/base'
 import { StringifyOptions } from 'querystring'
 import { getFace, getMsgRawTxt } from '@/function/utils/msgUtil'
-import { openLink, downloadFile } from '@/function/utils/appUtil'
+import { openLink, downloadFile, sendStatEvent } from '@/function/utils/appUtil'
 import { getSizeFromBytes } from '@/function/utils/systemUtil'
 
 export default defineComponent({
     name: 'MsgBody',
-    props: ['data', 'type'],
+    props: ['data', 'type', 'selected'],
     components: { CardMessage },
     data () {
         return {
@@ -343,25 +342,23 @@ export default defineComponent({
                             }
                             this.pageViewInfo = pageData
                         }
-                        // UM：上传使用链接预览功能的事件用于分析（成功）
                         const reg1 = /\/\/(.*?)\//g
                         const getDom = fistLink.match(reg1)
                         if (getDom !== null) {
-                            Umami.trackEvent('link_view', { domain: RegExp.$1, statue: true })
+                            sendStatEvent('link_view', { domain: RegExp.$1, statue: true })
                         } else {
-                            Umami.trackEvent('link_view', { domain: '', statue: true })
+                            sendStatEvent('link_view', { domain: '', statue: true })
                         }
                     })
                     .catch(error => {
                         if (error) {
                             logger.error(error as Error, '获取链接预览失败: ' + fistLink)
-                            // UM：上传使用链接预览功能的事件用于分析（失败）
                             const reg1 = /\/\/(.*?)\//g
                             const getDom = fistLink.match(reg1)
                             if (getDom !== null) {
-                                Umami.trackEvent('link_view', { domain: RegExp.$1, statue: false })
+                                sendStatEvent('link_view', { domain: RegExp.$1, statue: false })
                             } else {
-                                Umami.trackEvent('link_view', { domain: '', statue: false })
+                                sendStatEvent('link_view', { domain: '', statue: false })
                             }
                         }
                     })

--- a/src/components/MsgBody.vue
+++ b/src/components/MsgBody.vue
@@ -32,14 +32,13 @@
                         <div v-if="item.type === undefined"></div>
                         <span v-else-if="isDebugMsg" class="msg-text">{{ item }}</span>
                         <span v-else-if="item.type == 'text'" @click="textClick" v-show="item.text !== ''" class="msg-text" v-html="parseText(item.text)"></span>
+                        <img v-else-if="item.type == 'image' && item.file == 'marketface'" @load="scrollButtom" @error="imgLoadFail" :class="imgStyle(data.message.length, index, item.asface) + ' msg-mface'" :src="item.url">
                         <img v-else-if="item.type == 'image'" :title="$t('预览图片')" :alt="$t('图片')" @load="scrollButtom" @error="imgLoadFail" @click="imgClick(data.message_id)" :class="imgStyle(data.message.length, index, item.asface)" :src="item.url">
                         <template v-else-if="item.type == 'face'">
                             <img v-if="getFace(item.id)" :alt="item.text" class="msg-face" :src="getFace(item.id)" :title="item.text">
                             <span v-else-if="item.id == 394" class="msg-face-long"><span v-for="i in 15" :key="data.message_id + '-l-' + i">🐲</span></span>
                             <font-awesome-icon v-else :class="'msg-face-svg' + (isMe ? ' me': '')" :icon="['fas', 'face-grin-wide']" />
                         </template>
-                        <img v-else-if="item.type == 'mface' && item.url" @load="scrollButtom" @error="imgLoadFail" :class="imgStyle(data.message.length, index, item.asface) + ' msg-mface'" :src="item.url">
-                        <span v-else-if="item.type == 'mface' && item.text" class="msg-unknown">{{ item.text }}</span>
                         <span v-else-if="item.type == 'bface'" style="font-style: italic;opacity: 0.7;">[ {{ $t('图片') }}：{{ item.text }} ]</span>
                         <div v-else-if="item.type == 'at'" :class="getAtClass(item.qq)">
                             <a @mouseenter="showUserInfo" :data-id="item.qq" :data-group="data.group_id">{{ getAtName(item) }}</a>

--- a/src/components/MsgBody.vue
+++ b/src/components/MsgBody.vue
@@ -13,7 +13,7 @@
     <div :class="'message' + (type ? ' ' + type : '') + (data.revoke ? ' revoke' : '') + (isMe ? ' me': '') + (selected ? ' selected' : '')" :data-raw="getMsgRawTxt(data)"
         :id="'chat-' + data.message_id" :data-sender="data.sender.user_id" :data-time="data.time"
         @mouseleave="hiddenUserInfo">
-        <img name="avatar" :src="'https://q1.qlogo.cn/g?b=qq&s=0&nk=' + data.sender.user_id" v-show="!isMe || type == 'merge'">
+        <img @dblclick="sendPoke" name="avatar" :src="'https://q1.qlogo.cn/g?b=qq&s=0&nk=' + data.sender.user_id" v-show="!isMe || type == 'merge'">
         <div class="message-space" v-if="isMe && type != 'merge'"></div>
         <div :class="isMe ? (type == 'merge' ? 'message-body' : 'message-body me') : 'message-body'">
             <template v-if="runtimeData.chatInfo.show.type == 'group' && !isMe && senderInfo?.title && senderInfo?.title != ''">
@@ -531,6 +531,11 @@ export default defineComponent({
                     hasCard = true
             }})
             return hasCard
+        },
+
+        sendPoke() {
+            // 调用上级组件的 poke 方法
+            this.$emit('sendPoke', this.data.sender.user_id)
         }
     },
     mounted () {

--- a/src/components/WelPan.vue
+++ b/src/components/WelPan.vue
@@ -42,11 +42,11 @@
 
 <script lang="ts">
 import languages from '@/assets/l10n/_l10nconfig.json'
-import Umami from '@stapxs/umami-logger-typescript'
 
 import { defineComponent } from 'vue'
 import { runtimeData } from '@/function/msg'
 import { runASWEvent as save } from '@/function/option'
+import { sendStatEvent } from '@/function/utils/appUtil'
 
 export default defineComponent({
     name: 'WelcomePan',
@@ -62,8 +62,7 @@ export default defineComponent({
     methods: {
         gaLanguage(event: Event) {
             const sender = event.target as HTMLInputElement
-            // UM：上传语言选择
-            Umami.trackEvent('use_language', { name: sender.value })
+            sendStatEvent('use_language', { name: sender.value })
             // 刷新菜单
             // TODO
         },

--- a/src/components/msg-component/CardMessage.vue
+++ b/src/components/msg-component/CardMessage.vue
@@ -17,8 +17,8 @@
     <div>
         <div v-if="item.type == 'xml'" v-html="View.buildXML(item.data, item.id, id)" @click="View.cardClick('xml-' + id)"></div>
         <div v-else>
-            <div v-if="info.type == 'default'" v-html="buildJSON(info, id)" @click="View.cardClick('json-' + id)"></div>
-            <div v-once v-else-if="info.type == 'tencent.map'" class="msg-comp-map" @click="View.cardClick('map-' + id)">
+            <div v-if="info?.type == 'default'" v-html="buildJSON(info, id)" @click="View.cardClick('json-' + id)"></div>
+            <div v-once v-else-if="info?.type == 'tencent.map'" class="msg-comp-map" @click="View.cardClick('map-' + id)">
                 <p>{{ info.app.title }}</p>
                 <span>{{ info.app.desc }}</span>
                 <div
@@ -44,7 +44,7 @@ export default defineComponent({
     data() {
         return {
             View: ViewFuns,
-            info: ViewFuns.getJSONType(this.item.data),
+            info: ViewFuns.getJSONType(this.item),
         }
     },
     methods: {
@@ -95,7 +95,7 @@ export default defineComponent({
                     lng: json.meta['Location.Search'].lng
                 }
             )
-            return this.info.app.url
+            return this.info?.app.url
         }
     }
 })

--- a/src/function/model/msg-body.ts
+++ b/src/function/model/msg-body.ts
@@ -148,51 +148,55 @@ export class MsgBodyFuns {
 
     /**
      * 获取具体的 JSON 消息类型用于特殊处理
-     * @param data JSON 消息
+     * @param msg 消息
      * @returns { type: string, app: any }
      */
-    static getJSONType(data: string) {
-        const json = JSON.parse(data)
-        const info = this.getJSON(json)
-        let type = 'default'
-        const append = {} as {[key: string]: any}
-        
-        // 下面就是一大堆特殊判定
-        if (json.desc === '群公告') {
-            info.title = json.desc
-            info.desc = json.prompt
-            info.preview = undefined
-            info.icon = ''
-            info.name = json.desc
-        }
-        if(json.app == 'com.tencent.multimsg') {
-            info.title = json.meta.detail.source
-            info.desc = '<div style="padding: 15px 20px 5px 20px">'
-            json.meta.detail.news.forEach((item: any) => {
-                info.desc += '<span>' + item.text + '</span><br>'
-            })
-            info.desc += '</div>'
-            info.icon = ''
-            info.name = json.meta.detail.summary
+    static getJSONType(msg: any) {
+        if(msg.type != 'xml') {
+            const data = msg.data
+            const json = JSON.parse(data)
+            const info = this.getJSON(json)
+            let type = 'default'
+            const append = {} as {[key: string]: any}
             
-            append.type = 'forward'
-            append.id = json.meta.detail.resid
-        }
-        if(json.app == 'com.tencent.map') {
-            info.title = json.meta['Location.Search'].name
-            append.urlOpenType = '_self'
-            const deviceType = getDeviceType()
-            if(deviceType == 'Android') {
-                info.url = 'geo:' + json.meta['Location.Search'].lat + ',' + json.meta['Location.Search'].lng
-            } else if(deviceType == 'iOS' || deviceType == 'MacOS') {
-                info.url = 'http://maps.apple.com/?ll=' + json.meta['Location.Search'].lat + ',' + json.meta['Location.Search'].lng +
-                    '&q=' + json.meta['Location.Search'].name
+            // 下面就是一大堆特殊判定
+            if (json.desc === '群公告') {
+                info.title = json.desc
+                info.desc = json.prompt
+                info.preview = undefined
+                info.icon = ''
+                info.name = json.desc
             }
-            info.desc = json.meta['Location.Search'].address
-            type = 'tencent.map'
-        }
+            if(json.app == 'com.tencent.multimsg') {
+                info.title = json.meta.detail.source
+                info.desc = '<div style="padding: 15px 20px 5px 20px">'
+                json.meta.detail.news.forEach((item: any) => {
+                    info.desc += '<span>' + item.text + '</span><br>'
+                })
+                info.desc += '</div>'
+                info.icon = ''
+                info.name = json.meta.detail.summary
+                
+                append.type = 'forward'
+                append.id = json.meta.detail.resid
+            }
+            if(json.app == 'com.tencent.map') {
+                info.title = json.meta['Location.Search'].name
+                append.urlOpenType = '_self'
+                const deviceType = getDeviceType()
+                if(deviceType == 'Android') {
+                    info.url = 'geo:' + json.meta['Location.Search'].lat + ',' + json.meta['Location.Search'].lng
+                } else if(deviceType == 'iOS' || deviceType == 'MacOS') {
+                    info.url = 'http://maps.apple.com/?ll=' + json.meta['Location.Search'].lat + ',' + json.meta['Location.Search'].lng +
+                        '&q=' + json.meta['Location.Search'].name
+                }
+                info.desc = json.meta['Location.Search'].address
+                type = 'tencent.map'
+            }
 
-        return { type, app: info, append }
+            return { type, app: info, append }
+        }
+        return null
     }
 
     /**

--- a/src/function/msg.ts
+++ b/src/function/msg.ts
@@ -22,7 +22,7 @@ import Umami from '@stapxs/umami-logger-typescript'
 
 import { buildMsgList, getMsgData, parseMsgList, getMsgRawTxt, updateLastestHistory, sendMsgAppendInfo } from '@/function/utils/msgUtil'
 import { getViewTime, escape2Html, randomNum } from '@/function/utils/systemUtil'
-import { reloadUsers, reloadCookies, downloadFile, updateMenu, jumpToChat, loadJsonMap } from '@/function/utils/appUtil'
+import { reloadUsers, reloadCookies, downloadFile, updateMenu, jumpToChat, loadJsonMap, sendStatEvent } from '@/function/utils/appUtil'
 import { reactive, markRaw, defineAsyncComponent } from 'vue'
 import { PopInfo, PopType, Logger, LogType } from './base'
 import { Connector, login } from './connect'
@@ -258,12 +258,11 @@ const msgFunctons = {
             resetRimtime(runtimeData.botInfo.app_name != data.app_name && !login.status)
 
             runtimeData.botInfo = data
-            // UM：提交分析信息，主要在意的是 bot 类型
             if (Option.get('open_ga_bot') !== false) {
                 if (data.app_name !== undefined) {
-                    Umami.trackEvent('connect', { method: data.app_name })
+                    sendStatEvent('connect', { method: data.app_name })
                 } else {
-                    Umami.trackEvent('connect', { method: '' })
+                    sendStatEvent('connect', { method: '（未知）' })
                 }
             }
             if (!login.status) {
@@ -705,9 +704,8 @@ const msgFunctons = {
      * 保存精华消息
      */
     getJin: (name: string, msg: { [key: string]: any }) => {
-        const data = msg.data
-        const jinList = getMsgData('group_essence', data, msgPath.group_essence)
-        const is_end = getMsgData('is_end', data, msgPath.group_essence.is_end)
+        const jinList = getMsgData('group_essence', msg, msgPath.group_essence)
+        const is_end = getMsgData('is_end', msg, msgPath.group_essence.is_end) ?? [true]
         if (jinList && is_end) {
             if (runtimeData.chatInfo.info.jin_info.list.length == 0) {
                 runtimeData.chatInfo.info.jin_info.list = jinList

--- a/src/function/option.ts
+++ b/src/function/option.ts
@@ -11,14 +11,13 @@
 */
 
 import app from '@/main'
-import Umami from '@stapxs/umami-logger-typescript'
 import languageConfig from '@/assets/l10n/_l10nconfig.json'
 
 import { i18n } from '@/main'
 import { markRaw, defineAsyncComponent } from 'vue'
 import { Logger, LogType, PopInfo, PopType } from './base'
 import { runtimeData } from './msg'
-import { initUITest, loadSystemThemeColor, loadWinColor, updateWinColor } from '@/function/utils/appUtil'
+import { loadSystemThemeColor, loadWinColor, sendStatEvent, updateWinColor } from '@/function/utils/appUtil'
 import { getPortableFileLang, getTrueLang } from '@/function/utils/systemUtil'
 
 let cacheConfigs: { [key: string]: any }
@@ -46,7 +45,6 @@ const configFunction: { [key: string]: (value: any) => void } = {
     opt_dark: setDarkMode,
     opt_auto_dark: setAutoDark,
     theme_color: changeTheme,
-    ui_test: changeUiTest,
     chatview_name: changeChatView,
     initial_scale: changeInitialScale,
     msg_type: setMsgType,
@@ -71,8 +69,7 @@ function viewRevolve(value: boolean) {
             save('opt_revolve', false)
         } else {
             baseApp.classList.add('no-touch')
-            // UM：上传禁用触摸(彩蛋)的选择
-            Umami.trackEvent('click_statistics', { name: 'touch_randomly' })
+            sendStatEvent('click_statistics', { name: 'touch_randomly' })
         }
     }
 }
@@ -97,16 +94,6 @@ function updateGTKColor(value: boolean) {
 function setMsgType(value: any) {
     if(value) {
         runtimeData.tags.msgType = Number(value)
-    }
-}
-
-/**
- * 启用 UI 测试模式以便于翻译等需要浏览全部 UI 的行为
- * @param value 是否启用 UI 测试模式
- */
-function changeUiTest(value: boolean) {
-    if (value === true) {
-        initUITest()
     }
 }
 

--- a/src/function/utils/appUtil.ts
+++ b/src/function/utils/appUtil.ts
@@ -1,8 +1,9 @@
 import app from '@/main'
 import FileDownloader from 'js-file-downloader'
-import option, { remove } from '@/function/option'
+import option from '@/function/option'
 import cmp from 'semver-compare'
 import appInfo from '../../../package.json'
+import Umami from '@stapxs/umami-logger-typescript'
 
 
 import AboutPan from '@/components/AboutPan.vue'
@@ -195,25 +196,6 @@ export function jumpToChat(userId: string, msgId: string) {
         // 当前聊天已经打开，是没有焦点触发的消息通知；直接滚动到消息。
         scrollToMsg(msgId, true)
     }
-}
-
-/**
- * 初始化构建 UI Test 的范例数据
- */
-export function initUITest() {
-    // 绕过登陆判定
-    runtimeData.loginInfo.status = true
-    runtimeData.loginInfo.info = { 'uin': 1111111111, 'lnick': '这只是测试用的数据', 'nick': '林小槐' }
-    // 填充运行时数据
-    // Vue.set(runtimeData, 'onChat', { "type": "group", "id": 1111111111, "name": "Stapxs QQ Lite 内测群", "avatar": "https://p.qlogo.cn/gh/1111111111/1111111111/0", "info": { "group": {}, "group_members": [{ "user_id": 2222222222, "nickname": "林小槐", "card": "", "level": 1, "role": "admin" }, { "user_id": 3333333333, "nickname": "HappyDay's  small ID", "card": "", "level": 1, "role": "member" }, { "user_id": 4444444444, "nickname": "晓狩", "card": "", "level": 1, "role": "member" }], "group_files": { "file_list": [{ "bus_id": 104, "create_time": 1669356711, "dead_time": 1670221311, "download_times": 2, "id": "/0d55f622-6c88-11ed-8d9f-5254001daf95", "md5": "8106ece97e5de9434d63faa991d8513f", "name": "901309905.mp4", "owner_name": "林小槐", "owner_uin": 2222222222, "parent_id": "/", "size": 161478663, "type": 1 }], "next_index": 0, "total_cnt": 1 }, "group_sub_files": {}, "user": {}, "me": { "group_id": 1111111111, "user_id": 2222222222, "nickname": "林小槐", "card": "", "level": 1, "role": "admin", "echo": "getUserInfoInGroup" }, "group_notices": { "feeds": [{ "u": 2222222222, "msg": { "text": "Stapxs QQ Lite 2.0 来辣，戳下面的链接去用用看 ……\nmemo 全新的 README（还有点感谢内容要写）\nsparkles 群公告支持（不支持图片）\nbug 修正在窄布局下，底栏被消息组件弹窗遮挡\nart 拆分 MsgBody 的部分方法便于之后的兼容复用\nsparkles 消息列表部分功能（打开自动添加到消息列表、新消息置顶、新消息提示、显示消息预览）\nbug 修正了好友列表搜索不支持备注的遗漏 \nhttps://stapxs.github.io/Stapxs-QQ-Lite-2.0/", "text_face": "Stapxs QQ Lite 2.0 来辣，戳下面的链接去用用看 ……\nmemo 全新的 README（还有点感谢内容要写）\nsparkles 群公告支持（不支持图片）\nbug 修正在窄布局下，底栏被消息组件弹窗遮挡\nart 拆分 MsgBody 的部分方法便于之后的兼容复用\nsparkles 消息列表部分功能（打开自动添加到消息列表、新消息置顶、新消息提示、显示消息预览）\nbug 修正了好友列表搜索不支持备注的遗漏 \nhttps://stapxs.github.io/Stapxs-QQ-Lite-2.0/", "title": "群公告" }, "read_num": 4, "is_read": 0 }] } } })
-    // Vue.set(runtimeData, 'userList', [{ "user_id": 3333333333, "nickname": "晓狩", "sex": "male", "remark": "" }, { "group_id": 1000000000, "group_name": "DHW ∞ 行在", "owner_id": 2222222222 }])
-    // Vue.set(runtimeData, 'onMsg', [{ "group_id": 1000000000, "group_name": "DHW ∞ 行在", "owner_id": 2222222222, "new_msg": false }, { "group_id": 1111111111, "group_name": "Stapxs QQ Lite 内测群", "owner_id": 2222222222, "new_msg": true }])
-    // Vue.set(runtimeData, 'messageList', [{ "post_type": "message", "message_id": "E/1", "user_id": 2222222222, "time": 1669898020, "seq": 9706, "rand": 1560268290, "font": "微软雅黑", "message": [{ "type": "text", "text": "又遇到个见鬼的 BUG ……" }], "raw_message": "又遇到个见鬼的 BUG ……", "message_type": "group", "sender": { "user_id": 2222222222, "nickname": "林小槐", "card": "" }, "group_id": 1111111111, "atme": false, "atall": false }, { "post_type": "message", "message_id": "E/2", "user_id": 2222222222, "time": 1669898020, "seq": 9706, "rand": 1560268290, "font": "微软雅黑", "message": [{ "type": "text", "text": "https://github.com/Stapxs/Stapxs-QQ-Lite-2.0" }], "raw_message": "https://github.com/Stapxs/Stapxs-QQ-Lite-2.0", "message_type": "group", "sender": { "user_id": 2222222222, "nickname": "林小槐", "card": "" }, "group_id": 1111111111, "atme": false, "atall": false }, { "post_type": "message", "message_id": "E/3", "user_id": 2222222222, "time": 1669898020, "seq": 9706, "rand": 1560268290, "font": "微软雅黑", "message": [{ "type": "text", "text": "看看现在好没好" }], "raw_message": "看看现在好没好", "message_type": "group", "sender": { "user_id": 2222222222, "nickname": "林小槐", "card": "" }, "group_id": 1111111111, "atme": false, "atall": false }, { "post_type": "notice", "notice_type": "group", "group_id": 1111111111, "sub_type": "recall", "user_id": 2222222222, "operator_id": 2222222222, "message_id": "这个不重要", "self_id": 2222222222, "name": "林小槐", "time": 1669898020 }, { "post_type": "message", "message_id": "E/5", "user_id": 2222222222, "time": 1669943800, "seq": 114361, "rand": 3096699112, "font": "宋体", "message": [{ "type": "image", "file": "66cba6ff5b2364d27eb3d6ed4d2faeca92966-554-838.png", "url": "https://gchat.qpic.cn/gchatpic_new/1007028430/560932983-3133756386-66CBA6FF5B2364D27EB3D6ED4D2FAECA/0?term=2&is_origin=0", "asface": false }, { "type": "text", "text": " 像是这样翻译模式（UI 测试模式）应该就能用了 hummmm" }], "raw_message": "[图片] 像是这样翻译模式（UI 测试模式）应该就能用了 hummmm", "message_type": "group", "sender": { "user_id": 2222222222, "nickname": "林小槐 - Stapx_Steve", "card": "林小槐 - Stapx_Steve", "level": 1, "role": "admin" }, "group_id": 1111111111 }])
-    // Vue.set(runtimeData, 'botInfo', { "app_name": "oicq2", "version": "2.3.1", "http_api": "1.1.0", "stat": { "start_time": 1669940663, "lost_times": 0, "recv_pkt_cnt": 30, "sent_pkt_cnt": 24, "lost_pkt_cnt": 0, "recv_msg_cnt": 1, "sent_msg_cnt": 0, "msg_cnt_per_min": 0, "remote_ip": "58.212.179.115", "remote_port": 8080 } })
-    // Vue.set(runtimeData, 'loginInfo', { "uin": 2222222222, "status": "online", "nickname": "林小槐", "sex": "male" })
-    // Vue.set(runtimeData, 'showData', [{ "group_id": 1000000000, "group_name": "DHW ∞ 行在", "owner_id": 2222222222 }, { "user_id": 3333333333, "nickname": "晓狩", "sex": "male", "remark": "" }])
-    // Vue.set(runtimeData, 'mergeMessageList', [{ "user_id": 2222222222, "time": 1669942039, "nickname": "林小槐 - Stapx_Steve", "group_id": 1111111111, "message": [{ "type": "image", "file": "6b02169dd9cb486330e400fdebf8312a5310-290-290.jpg", "url": "https://gchat.qpic.cn/gchatpic_new/1007028430/560932983-2842238012-6B02169DD9CB486330E400FDEBF8312A/0?term=2&is_origin=0", "asface": true }], "raw_message": "[动画表情]", "sender": { "user_id": 2222222222, "nickname": "林小槐 - Stapx_Steve", "card": "林小槐 - Stapx_Steve" } }, { "time": 1669893493, "user_id": 2222222222, "nickname": "林小槐 - Stapx_Steve", "group_id": 1111111111, "message": [{ "type": "text", "text": "烦内" }], "raw_message": "烦内", "sender": { "user_id": 2222222222, "nickname": "林小槐 - Stapx_Steve", "card": "林小槐 - Stapx_Steve" } }])
-    // Vue.set(runtimeData, 'stickers', [])
 }
 
 /**
@@ -421,7 +403,7 @@ export function createIpc() {
             popInfo.add(PopType.INFO, app.config.globalProperties.$t('刷新用户列表成功'))
         })
         runtimeData.reader.on('bot:logout', () => {
-            remove('auto_connect')
+            option.remove('auto_connect')
             Connector.close()
         })
         runtimeData.reader.on('bot:quickReply', (event, data) => {
@@ -763,4 +745,11 @@ export function loadJsonMap(name: string) {
         }
     }
     return msgPath
+}
+
+// UM：统计事件统一上传方法
+export function sendStatEvent(event: string, data: any) {
+    if (!option.get('close_ga') && process.env.NODE_ENV == 'production') {
+        Umami.trackEvent(event, data)
+    }
 }

--- a/src/function/utils/msgUtil.ts
+++ b/src/function/utils/msgUtil.ts
@@ -429,6 +429,10 @@ export function updateLastestHistory(item: UserFriendElem & UserGroupElem) {
 }
 
 export function sendMsgAppendInfo(msg: any) {
-    msg
-    // TODO
+    if(msg.message) {
+        msg.message.forEach(() => {
+            // TODO
+        }
+        )
+    }
 }

--- a/src/function/utils/msgUtil.ts
+++ b/src/function/utils/msgUtil.ts
@@ -1,12 +1,12 @@
 import jp from 'jsonpath'
 import app from '@/main'
-import Umami from '@stapxs/umami-logger-typescript'
 
 import { Logger } from '@/function/base'
 import { runtimeData } from '@/function/msg'
 import { v4 as uuid } from 'uuid'
 import { Connector } from '@/function/connect'
 import { BotMsgType, UserFriendElem, UserGroupElem } from '../elements/information'
+import { sendStatEvent } from './appUtil'
 
 const logger = new Logger()
 
@@ -337,7 +337,7 @@ export function parseCQ(data: any) {
     return data
 }
 
-export function sendMsgRaw(id: string, type: string, msg: string | { type: string; text: string; }[] | undefined, preShow = false) {
+export function sendMsgRaw(id: string, type: string, msg: string | any[] | undefined, preShow = false) {
     // 将消息构建为完整消息体先显示出去
     const msgUUID = uuid()
     if (preShow) {
@@ -401,8 +401,7 @@ export function sendMsgRaw(id: string, type: string, msg: string | { type: strin
                 break
             }
         }
-        // UM：统计消息发送次数
-        Umami.trackEvent('sendMsg', { type: type })
+        sendStatEvent('sendMsg', { type: type })
     }
 }
 

--- a/src/function/utils/msgUtil.ts
+++ b/src/function/utils/msgUtil.ts
@@ -220,9 +220,8 @@ export function getMsgRawTxt(data: any): string {
                 // eslint-disable-next-line
                 case 'text': back += message[i].text.replaceAll('\n', ' ').replaceAll('\r', ' '); break
                 case 'face': back += '[' + $t('表情') + ']'; break
-                case 'mface': back += message[i].summary ?? message[i].text; break
                 case 'bface': back += message[i].text; break
-                case 'image': back += '[' + $t('图片') + ']'; break
+                case 'image': back += message[i].summary ?? '[' + $t('图片') + ']'; break
                 case 'record': back += '[' + $t('语音') + ']'; break
                 case 'video': back += '[' + $t('视频') + ']'; break
                 case 'file': back += '[' + $t('文件') + ']'; break
@@ -430,7 +429,6 @@ export function updateLastestHistory(item: UserFriendElem & UserGroupElem) {
 }
 
 export function sendMsgAppendInfo(msg: any) {
-    msg.message.forEach(() => {
-        // TODO
-    })
+    msg
+    // TODO
 }

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -357,10 +357,6 @@
                     <div><font-awesome-icon :icon="['fas', 'floppy-disk']" /></div>
                     <a>{{ $t('下载图片') }}</a>
                 </div>
-                <div @click="addStoreFace" v-show="tags.menuDisplay.addStoreFace != false">
-                    <div><font-awesome-icon :icon="['fas', 'heart']" /></div>
-                    <a>{{ $t('收藏商城表情') }}</a>
-                </div>
                 <div @click="revokeMsg" v-show="tags.menuDisplay.revoke">
                     <div><font-awesome-icon :icon="['fas', 'xmark']" /></div>
                     <a>{{ $t('撤回') }}</a>
@@ -454,7 +450,6 @@ import { Logger, LogType, PopInfo, PopType } from '@/function/base'
 import { Connector, login as loginInfo } from '@/function/connect'
 import { runtimeData} from '@/function/msg'
 import { BaseChatInfoElem, MsgItemElem, SQCodeElem, GroupMemberInfoElem, UserFriendElem, UserGroupElem } from '@/function/elements/information'
-import option from '@/function/option'
 
 export default defineComponent({
     name: 'ViewChat',
@@ -493,7 +488,6 @@ export default defineComponent({
                     copy: true,
                     copySelect: false,
                     downloadImg: false as string | false,
-                    addStoreFace: false,
                     revoke: false,
                     at: true,
                     remove: false,
@@ -854,9 +848,7 @@ export default defineComponent({
                             this.tags.menuDisplay.add = false
                         }
                     })
-                    if(data.message[0].type == 'mface') {
-                        this.tags.menuDisplay.addStoreFace = true
-                    } else if(select.nodeName == 'IMG') {
+                    if(select.nodeName == 'IMG') {
                         // 右击图片需要显示的内容，这边特例设置为链接
                         this.tags.menuDisplay.downloadImg = (select as HTMLImageElement).src
                     }
@@ -913,7 +905,6 @@ export default defineComponent({
                 copy: true,
                 copySelect: false,
                 downloadImg: false,
-                addStoreFace: false,
                 revoke: false,
                 at: false,
                 remove: false,
@@ -1105,30 +1096,6 @@ export default defineComponent({
                     user.click()
                 }
             })
-        },
-
-        /**
-         * 添加商城表情
-         */
-        addStoreFace() {
-            const popInfo = new PopInfo()
-            const msg = this.selectedMsg
-            if (msg !== null) {
-            const mface = msg.message[0]
-                const storeFaceList = option.get('store_face') ?? []
-                const face = storeFaceList.find((item: any) => {
-                    return item.emoji_package_id == mface.emoji_package_id && 
-                        item.emoji_id == mface.emoji_id
-                })
-                if(face) {
-                    popInfo.add(PopType.INFO, this.$t('表情已被收藏'))
-                } else {
-                    storeFaceList.push(mface)
-                    option.save('store_face', storeFaceList)
-                    popInfo.add(PopType.INFO, this.$t('表情收藏成功'))
-                }
-            }
-            this.closeMsgMenu()
         },
 
         /**
@@ -1625,7 +1592,7 @@ export default defineComponent({
                     this.list.forEach((item: any) => {
                         if (item.message !== undefined) {
                             item.message.forEach((msg: MsgItemElem) => {
-                                if (msg.type === 'image' && !msg.asface) {
+                                if (msg.type === 'image' && msg.file != 'marketface') {
                                     const info = {
                                         index: item.message_id,
                                         message_id: item.message_id,

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -57,7 +57,9 @@
                     <MsgBody
                         v-if="(msg.post_type === 'message' || msg.post_type === 'message_sent') && msg.message.length > 0"
                         :key="msg.message_id"
+                        :selected="multipleSelectList.includes(msg.message_id) || tags.openedMenuMsg?.id == 'chat-' + msg.message_id"
                         :data="msg"
+                        @click="msgClick($event, msg)"
                         @scrollToMsg="scrollToMsg"
                         @scrollButtom="imgLoadedScroll"
                         @contextmenu.prevent="showMsgMeun($event, msg)"
@@ -71,6 +73,7 @@
             </TransitionGroup>
         </div>
         <div v-else class="chat" id="msgPan" style="scroll-behavior: smooth;">
+            <!-- 搜索消息结果显示 -->
             <TransitionGroup name="msglist" tag="div">
                 <template v-for="(msg, index) in tags.search.list">
                     <!-- 时间戳 -->
@@ -79,6 +82,7 @@
                     <MsgBody
                         v-if="(msg.post_type === 'message' || msg.post_type === 'message_sent') && msg.message.length > 0"
                         :key="msg.message_id"
+                        :selected="multipleSelectList.includes(msg.message_id) || tags.openedMenuMsg?.id == 'chat-' + msg.message_id"
                         :data="msg"
                         @scrollToMsg="scrollToMsg"
                         @scrollButtom="imgLoadedScroll"
@@ -148,8 +152,32 @@
                         </div>
                     </Transition>
                 </div>
+                <!-- 多选指示器 -->
+                <div :class="multipleSelectList.length > 0 ? 'select-tag show' : 'select-tag'">
+                    <div>
+                        <font-awesome-icon @click="showForWard" :icon="['fas', 'share']" />
+                        <span>{{ $t('合并转发') }}</span>
+                    </div>
+                    <div>
+                        <font-awesome-icon :icon="['fas', 'scissors']" />
+                        <span>{{ $t('截图') }}</span>
+                    </div>
+                    <div>
+                        <font-awesome-icon @click="delMsgs" :icon="['fas', 'trash-can']" />
+                        <span>{{ $t('删除') }}</span>
+                    </div>
+                    <div>
+                        <font-awesome-icon @click="copyMsgs" :icon="['fas', 'copy']" />
+                        <span>{{ $t('复制') }}</span>
+                    </div>
+                    <div>
+                        <span @click="multipleSelectList = []">{{ multipleSelectList.length  }}</span>
+                        <!-- <font-awesome-icon @click="multipleSelectList = []" :icon="['fas', 'xmark']" /> -->
+                        <span>{{ $t('取消') }}</span>
+                    </div>
+                </div>
                 <!-- 搜索指示器 -->
-                 <div :class="details[3].open ? 'search-tag show' : 'search-tag'">
+                <div :class="details[3].open ? 'search-tag show' : 'search-tag'">
                     <font-awesome-icon :icon="['fas', 'search']" />
                     <span>{{ $t('搜索已加载的消息') }}</span>
                     <div @click="closeSearch"><font-awesome-icon :icon="['fas', 'xmark']" /></div>
@@ -189,7 +217,7 @@
                         <font-awesome-icon :icon="['fas', 'face-laugh']" />
                     </div>
                     <div :title="$t('戳一戳')" v-if="chat.show.type === 'user'" @click="sendPoke">
-                        <font-awesome-icon :icon="['fas', 'bomb']" /></div>
+                        <font-awesome-icon :icon="['fas', 'fa-hand-point-up']" /></div>
                     <div :title="$t('精华消息')" v-if="chat.show.type === 'group'" @click="showJin">
                         <font-awesome-icon :icon="['fas', 'star']" /></div>
                     <div class="space"></div>
@@ -204,8 +232,7 @@
                 </div>
                 <div>
                     <form @submit.prevent="mainSubmit">
-                        <input
-                            v-if="!Option.get('use_breakline')"
+                        <input v-if="!Option.get('use_breakline')"
                             id="main-input"
                             type="text"
                             v-model="msg"
@@ -217,8 +244,7 @@
                             @keyup="mainKeyUp"
                             @click="selectSQIn()"
                             @input="searchMessage">
-                        <textarea
-                            v-else
+                        <textarea v-else
                             id="main-input"
                             type="text"
                             v-model="msg"
@@ -315,10 +341,10 @@
                    <div><font-awesome-icon :icon="['fas', 'share']" /></div>
                    <a>{{ $t('转发') }}</a>
                 </div>
-                <!-- <div v-show="tags.menuDisplay.select">
-           <div><font-awesome-icon :icon="['fas', 'circle-check']" /></div>
-           <a>{{ $t('多选') }}</a>
-        </div> -->
+                <div @click="intoMultipleSelect()" v-show="tags.menuDisplay.select">
+                    <div><font-awesome-icon :icon="['fas', 'circle-check']" /></div>
+                    <a>{{ $t('多选') }}</a>
+                </div>
                 <div @click="copyMsg" v-show="tags.menuDisplay.copy">
                     <div><font-awesome-icon :icon="['fas', 'clipboard']" /></div>
                     <a>{{ $t('复制') }}</a>
@@ -383,7 +409,7 @@
                 <div class="ss-card card">
                     <header>
                         <span>{{ $t('转发消息') }}</span>
-                        <font-awesome-icon  @click="cancelForward" :icon="['fas', 'xmark']" />
+                        <font-awesome-icon @click="cancelForward" :icon="['fas', 'xmark']" />
                     </header>
                     <input @input="searchForward" :placeholder="$t('搜索 ……')">
                     <div>
@@ -421,7 +447,7 @@ import imageCompression from 'browser-image-compression'
 import { defineComponent, markRaw, reactive } from 'vue'
 import { v4 as uuid } from 'uuid'
 import { downloadFile, loadHistory as loadHistoryFirst } from '@/function/utils/appUtil'
-import { getTimeConfig, getTrueLang } from '@/function/utils/systemUtil'
+import { getTimeConfig, getTrueLang, getViewTime } from '@/function/utils/systemUtil'
 import { getMsgRawTxt, sendMsgRaw, getFace } from '@/function/utils/msgUtil'
 import { scrollToMsg } from '@/function/utils/appUtil'
 import { Logger, LogType, PopInfo, PopType } from '@/function/base'
@@ -447,6 +473,7 @@ export default defineComponent({
             getTimeConfig: getTimeConfig,
             forwardList: runtimeData.userList,
             trueLang: getTrueLang(),
+            multipleSelectList: [] as string[],
             tags: {
                 nowGetHistroy: false,
                 showBottomButton: true,
@@ -462,7 +489,7 @@ export default defineComponent({
                     add: true,
                     relpy: true,
                     forward: true,
-                    select: false,
+                    select: true,
                     copy: true,
                     copySelect: false,
                     downloadImg: false as string | false,
@@ -732,6 +759,11 @@ export default defineComponent({
             if (Option.get('log_level') === 'debug') {
                 new Logger().debug('右击消息：' + data)
             }
+            // 如果开着多选模式，不打开右击菜单
+            if(this.multipleSelectList.length > 0) {
+                return
+            }
+
             const menu = document.getElementById('msgMenu')
             let msg = event.currentTarget as HTMLDivElement
             const select = event.target as HTMLElement
@@ -785,6 +817,7 @@ export default defineComponent({
                         this.tags.menuDisplay.relpy = false
                         this.tags.menuDisplay.forward = false
                         this.tags.menuDisplay.revoke = false
+                        this.tags.menuDisplay.select = false
                     }
                     const selection = document.getSelection()
                     const textBody = selection?.anchorNode?.parentElement
@@ -864,9 +897,7 @@ export default defineComponent({
                         menu.style.marginTop = (bodyHeight - menuHeight - 10) + 'px'
                     }
                 }, 100)
-                // 设置消息背景
                 this.tags.openedMenuMsg = msg
-                msg.style.background = '#00000008'
             }
         },
 
@@ -878,7 +909,7 @@ export default defineComponent({
                 add: true,
                 relpy: true,
                 forward: true,
-                select: false,
+                select: true,
                 copy: true,
                 copySelect: false,
                 downloadImg: false,
@@ -967,25 +998,79 @@ export default defineComponent({
             this.closeMsgMenu()
         },
 
+        intoMultipleSelect() {
+            if (this.selectedMsg) {
+                this.multipleSelectList.push(this.selectedMsg.message_id)
+            }
+            this.closeMsgMenu()
+        },
+
         /**
          * 转发消息
          */
         forwardMsg (data: UserFriendElem & UserGroupElem) {
-            if (this.selectedMsg) {
-                const msg = this.selectedMsg
-                const id = data.group_id ? data.group_id : data.user_id
-                // 关闭转发窗口
-                this.cancelForward()
-                // 将接收目标加入消息列表并跳转过去
-                if (runtimeData.onMsgList.indexOf(data) < 0) {
-                    runtimeData.onMsgList.push(data)
-                }
-                this.$nextTick(() => {
-                    const user = document.getElementById('user-' + id)
-                    if(user) {
-                        user.click()
+            const msg = this.selectedMsg
+            const id = data.group_id ? data.group_id : data.user_id
+            if(this.multipleSelectList.length > 0 && msg) {
+                // 构造一条假的 json 消息用来渲染
+                const msgList = this.multipleSelectList.map((item) => {
+                    const msg = runtimeData.messageList.find((msg) => {
+                        return msg.message_id == item
+                    })
+                    if(msg) {
+                        return msg
                     }
                 })
+                // 构造 titleList
+                const jsonMsg = {
+                    app: 'com.tencent.multimsg',
+                    meta: {
+                        detail: {
+                            source: '合并转发的消息',
+                            news: [
+                                ...msgList.slice(0, 3).map((item) => {
+                                    const name = item.sender.card && item.sender.card != '' ? item.sender.card : item.sender.nickname
+                                    return {
+                                        text: name + ': ' + getMsgRawTxt(item)
+                                    }
+                                })
+                            ],
+                            summary: '查看' + this.multipleSelectList.length + '条转发消息',
+                            resid: ''
+                        }
+                    }
+                }
+                msg.message = [{ type: 'json', data: JSON.stringify(jsonMsg), id: '' }]
+                msg.sender = { user_id: runtimeData.loginInfo.uin, nickname: runtimeData.loginInfo.nickname }
+                // 二次确认转发
+                const popInfo = {
+                    title: this.$t('合并转发消息'),
+                    template: MsgBody,
+                    templateValue: markRaw({data: msg, type: 'forward'}),
+                    button: [
+                        {
+                            text: this.$t('取消'),
+                            fun: () => { runtimeData.popBoxList.shift() }
+                        },
+                        {
+                            text: this.$t('确定'),
+                            master: true,
+                            fun: () => {
+                                // 构建消息体
+                                const msgBody = msgList.map((item) => {
+                                    return {
+                                        type: 'node',
+                                        id: item.message_id
+                                    }
+                                })
+                                sendMsgRaw(this.chat.show.id, this.chat.show.type, msgBody, true)
+                                runtimeData.popBoxList.shift()
+                            }
+                        }
+                    ]
+                }
+                runtimeData.popBoxList.push(popInfo)
+            } else if (this.selectedMsg && msg) {
                 // 二次确认转发
                 const popInfo = {
                     title: this.$t('转发消息'),
@@ -1008,6 +1093,18 @@ export default defineComponent({
                 }
                 runtimeData.popBoxList.push(popInfo)
             }
+            // 关闭转发窗口
+            this.cancelForward()
+            // 将接收目标加入消息列表并跳转过去
+            if (runtimeData.onMsgList.indexOf(data) < 0) {
+                runtimeData.onMsgList.push(data)
+            }
+            this.$nextTick(() => {
+                const user = document.getElementById('user-' + id)
+                if(user) {
+                    user.click()
+                }
+            })
         },
 
         /**
@@ -1159,9 +1256,7 @@ export default defineComponent({
         closeMsgMenu () {
             // 关闭菜单
             this.tags.showMsgMenu = false
-            // 清理消息背景
-            if(this.tags.openedMenuMsg)
-                this.tags.openedMenuMsg.style.background = 'unset'
+            if(this.tags.openedMenuMsg) this.tags.openedMenuMsg = null
             setTimeout(() => {
                 // 重置菜单显示状态
                 this.initMenuDisplay()
@@ -1567,6 +1662,48 @@ export default defineComponent({
             }
         },
 
+        msgClick(event: Event, data: any) {
+            const message_id = data.message_id
+            if(this.multipleSelectList.length > 0) {
+                if(this.multipleSelectList.indexOf(message_id) > -1) {
+                    this.multipleSelectList = this.multipleSelectList.filter((item) => {
+                        return item != message_id
+                    })
+                } else {
+                    this.multipleSelectList.push(message_id)
+                }
+            }
+        },
+
+        delMsgs() {
+            new PopInfo().add(PopType.INFO, this.$t('欸嘿，这个按钮只是用来占位置的'))
+        },
+
+        copyMsgs() {
+            const msgList = this.list.filter((item: any) => {
+                return this.multipleSelectList.indexOf(item.message_id) > -1
+            })
+            let msg = ''
+            let lastDate = ''
+            msgList.forEach((item: any) => {
+                // 去除 item.time 时间戳中的时间，只保留日期
+                const time = new Date(getViewTime(item.time))
+                const date = time.getFullYear() + '-' + (time.getMonth() + 1) + '-' + time.getDate()
+                if(date != lastDate) {
+                    msg += '\n—— ' + date + ' ——\n'
+                    lastDate = date
+                }
+                msg += item.sender.nickname + ' ' + time.getHours() + ':' + time.getMinutes() + ':' + time.getSeconds() + '\n' + getMsgRawTxt(item) + '\n\n'
+            })
+            const popInfo = new PopInfo()
+            app.config.globalProperties.$copyText(msg).then(() => {
+                popInfo.add(PopType.INFO, this.$t('复制成功'), true)
+                this.multipleSelectList = []
+            }, () => {
+                popInfo.add(PopType.ERR, this.$t('复制失败'), true)
+            })
+        },
+
         /**
          * 消息触屏开始
          * @param event 触摸事件
@@ -1713,8 +1850,16 @@ export default defineComponent({
          * 发送戳一戳
          */
         sendPoke() {
-            let msg = SendUtil.parseMsg('[SQ:0]', [{ type: 'poke', _type: 1, id: -1, name: '戳一戳' }], this.imgCache)
-            sendMsgRaw(this.chat.show.id, this.chat.show.type, msg)
+            if(runtimeData.jsonMap.poke) {
+                let name = runtimeData.jsonMap.poke.name
+                if(this.chat.show.type == 'user' && runtimeData.jsonMap.poke.private_name) {
+                    name = runtimeData.jsonMap.poke.private_name
+                }
+                Connector.send(name, {
+                    user_id: this.chat.show.id,
+                    group_id: this.chat.show.id
+                }, 'sendPoke')
+            }
             this.tags.showMoreDetail = !this.tags.showMoreDetail
         },
 
@@ -1764,6 +1909,7 @@ export default defineComponent({
             this.msgMenus = data.msgMenus
             this.sendCache = []
             this.imgCache = [] as string[]
+            this.multipleSelectList = []
             this.initMenuDisplay()
         }
     },

--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -65,7 +65,8 @@
                         @contextmenu.prevent="showMsgMeun($event, msg)"
                         @touchstart="msgStartMove($event, msg)"
                         @touchmove="msgOnMove"
-                        @touchend="msgMoveEnd($event, msg)">
+                        @touchend="msgMoveEnd($event, msg)"
+                        @sendPoke="sendPoke">
                     </MsgBody>
                     <!-- 其他通知消息 -->
                     <NoticeBody :id="uuid()" v-if="msg.post_type === 'notice'" :key="'notice-' + index" :data="msg"></NoticeBody>
@@ -216,7 +217,7 @@
                         @click="details[1].open = !details[1].open, tags.showMoreDetail = false">
                         <font-awesome-icon :icon="['fas', 'face-laugh']" />
                     </div>
-                    <div :title="$t('戳一戳')" v-if="chat.show.type === 'user'" @click="sendPoke">
+                    <div :title="$t('戳一戳')" v-if="chat.show.type === 'user'" @click="sendPoke(chat.show.id)">
                         <font-awesome-icon :icon="['fas', 'fa-hand-point-up']" /></div>
                     <div :title="$t('精华消息')" v-if="chat.show.type === 'group'" @click="showJin">
                         <font-awesome-icon :icon="['fas', 'star']" /></div>
@@ -365,6 +366,10 @@
                     <div><font-awesome-icon :icon="['fas', 'at']" /></div>
                     <a>{{ $t('提及') }}</a>
                 </div>
+                <div @click="sendPoke(selectedMsg ? selectedMsg.sender.user_id : undefined)" v-show="tags.menuDisplay.poke">
+                    <div><font-awesome-icon :icon="['fas', 'fa-hand-point-up']" /></div>
+                    <a>{{ $t('戳一戳') }}</a>
+                </div>
                 <div @click="removeUser" v-show="tags.menuDisplay.remove">
                     <div><font-awesome-icon :icon="['fas', 'trash-can']" /></div>
                     <a>{{ $t('移出群聊') }}</a>
@@ -490,6 +495,7 @@ export default defineComponent({
                     downloadImg: false as string | false,
                     revoke: false,
                     at: true,
+                    poke: false,
                     remove: false,
                     respond: false,
                     showRespond: true
@@ -786,6 +792,7 @@ export default defineComponent({
                     })
                     this.tags.menuDisplay.showRespond = false
                     this.tags.menuDisplay.at = true
+                    this.tags.menuDisplay.poke = true
                     this.tags.menuDisplay.remove = true
                     if(runtimeData.chatInfo.show.type != 'group' ||
                         data.sender.user_id === runtimeData.loginInfo.uin ||
@@ -907,6 +914,7 @@ export default defineComponent({
                 downloadImg: false,
                 revoke: false,
                 at: false,
+                poke: false,
                 remove: false,
                 respond: false,
                 showRespond: true
@@ -1816,18 +1824,19 @@ export default defineComponent({
         /**
          * 发送戳一戳
          */
-        sendPoke() {
+        sendPoke(user_id: number) {
             if(runtimeData.jsonMap.poke) {
                 let name = runtimeData.jsonMap.poke.name
                 if(this.chat.show.type == 'user' && runtimeData.jsonMap.poke.private_name) {
                     name = runtimeData.jsonMap.poke.private_name
                 }
                 Connector.send(name, {
-                    user_id: this.chat.show.id,
+                    user_id: user_id,
                     group_id: this.chat.show.id
                 }, 'sendPoke')
             }
-            this.tags.showMoreDetail = !this.tags.showMoreDetail
+            this.tags.showMoreDetail = false
+            this.tags.menuDisplay.poke = false
         },
 
         /**

--- a/src/pages/options/OptDev.vue
+++ b/src/pages/options/OptDev.vue
@@ -133,19 +133,6 @@
                         $t('执行')
                 }}</button>
             </div>
-            <div class="opt-item">
-                <font-awesome-icon :icon="['fas', 'mountain']" />
-                <div>
-                    <span>{{ $t('页面测试') }}</span>
-                    <span>{{ $t('让我康康 ~') }}</span>
-                </div>
-                <label class="ss-switch">
-                    <input type="checkbox" @change="save" name="ui_test" v-model="runtimeData.sysConfig.ui_test">
-                    <div>
-                        <div></div>
-                    </div>
-                </label>
-            </div>
             <template v-if="runtimeData.tags.isElectron">
                 <div class="opt-item">
                     <font-awesome-icon :icon="['fas', 'power-off']" />
@@ -197,7 +184,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { runASWEvent as save, saveAll } from '@/function/option'
+import { run, runASWEvent as save, saveAll } from '@/function/option'
 import { Connector } from '@/function/connect'
 import { PopInfo, PopType } from '@/function/base'
 import { runtimeData } from '@/function/msg'
@@ -217,6 +204,7 @@ export default defineComponent({
             BotMsgType: BotMsgType,
             runtimeData: runtimeData,
             save: save,
+            run: run,
             ws_text: '',
             appmsg_text: ''
         }

--- a/src/pages/options/OptView.vue
+++ b/src/pages/options/OptView.vue
@@ -211,8 +211,6 @@
 </template>
 
 <script lang="ts">
-import Umami from '@stapxs/umami-logger-typescript'
-
 import { defineComponent, toRaw } from 'vue'
 import { runtimeData } from '../../function/msg'
 import { runASWEvent as save, get } from '../../function/option'
@@ -220,6 +218,7 @@ import { BrowserInfo, detect } from 'detect-browser'
 import { getDeviceType } from '@/function/utils/systemUtil'
 
 import languages from '../../assets/l10n/_l10nconfig.json'
+import { sendStatEvent } from '@/function/utils/appUtil'
 
 export default defineComponent({
     name: 'ViewOptTheme',
@@ -240,20 +239,17 @@ export default defineComponent({
     methods: {
         gaLanguage(event: Event) {
             const sender = event.target as HTMLInputElement
-            // UM：上传语言选择
-            Umami.trackEvent('use_language', { name: sender.value })
+            sendStatEvent('use_language', { name: sender.value })
         },
 
         gaChatView(event: Event) {
             const sender = event.target as HTMLInputElement
-            // UM：上传Chat View 选择
-            Umami.trackEvent('use_chatview', { name: sender.value })
+            sendStatEvent('use_chatview', { name: sender.value })
         },
 
         gaColor(event: Event) {
             const sender = event.target as HTMLInputElement
-            // UM：上传主题颜色选择
-            Umami.trackEvent('use_theme_color', { name: this.colors[Number(sender.dataset.id)] })
+            sendStatEvent('use_theme_color', { name: this.colors[Number(sender.dataset.id)] })
         },
 
         setInitialScaleShow(event: Event) {


### PR DESCRIPTION
更新内容：
:sparkles: 支持 Napcat 3.0 戳一戳功能
:sparkles: 对 image 形式的 mface 进行支持，移除对 mface 的支持
:sparkles: 多选消息以及合并转发消息支持
:art: 优化统计信息提交，合并为同一个方法
:bug: 对 napcat 调整过的精华消息接口支持
:poop: 移除对商城表情发送的功能支持，已经存储在设置项内的数据可能需要手动删除后重新导入
:poop: UI Debug 模式彻底移除
:heavy_plus_sign: 更新依赖：vue3-bcui
