### PR TITLE
kde6似乎有一些兼容性问题，我勉强是给修了

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stapxs-qq-lite",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "private": false,
   "author": "Stapx Steve [林槐]",
   "description": "一个兼容 OneBot 的非官方网页版 QQ 客户端，使用 Vue 重制的全新版本。",

--- a/src/assets/css/append/append_linux.css
+++ b/src/assets/css/append/append_linux.css
@@ -109,6 +109,6 @@
 
 @media (max-width: 500px) {
     .friend-list>div:first-child {
-        margin: 80px 15px 0 10px !important;
+        margin: 80px 15px 0 0px !important;
     }
 }

--- a/src/assets/css/append/append_new.css
+++ b/src/assets/css/append/append_new.css
@@ -1,3 +1,9 @@
+html, body {
+    background: none;
+}
+.viewer {
+    margin-top: 10px 
+}
 .ss-button {
     height: 35px;
     font-size: 0.8rem;


### PR DESCRIPTION
transparent: true 
这个属性在kde6上似乎不起作用
我本地的环境Arch
```
Debug Info - 2024/10/29 02:06:24
================================
System Info:
    OS Name          -> Linux
    Browser Name     -> chrome
    Browser Version  -> 118.0.5993
    Electron Version -> 27.3.11
    Install Type     -> aur
Application Info:
    Uptime           -> 109.88 s
    Package Version  -> 2.9.2
    Runtime env      -> production
    Service Work     -> false
Backend Info:
    Bot Info Name    -> NapCat.Onebot
    Bot Info Version -> 3.1.3
    Loaded Config    -> NapCat.Onebot
View Info:
    Doc Width        -> 1018 px
Network Info:
    Github           -> 548 ms
    Link API         -> failed
```

![屏幕截图_20241029_015610](https://github.com/user-attachments/assets/243d616e-2717-45cd-9163-8cfe0f394bf5)

这个溢出的父组件上甚至有时候还会显示点莫名其妙的东西，我实在看着受不了了自己勉强修了一下，没有十分仔细的改css，直接把圆角去掉了（

![屏幕截图_20241029_015811](https://github.com/user-attachments/assets/f04dede5-d713-4dcf-abfb-7c2a3d6895fb)

我白嫖了这么久多少来贡献点代码，如果愿意合并的话（