### PR TITLE
允许部署在子目录下

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ import { visualizer } from 'rollup-plugin-visualizer'
 /** @type {import('vite').UserConfig} */
 export default defineConfig({
     root: './src/renderer',
-    base: process.env.BUILD_ENV == 'github-actions'? '/Stapxs-QQ-Lite-2.0/' : undefined,
+    base: process.env.BUILD_ENV == 'github-actions'? '/Stapxs-QQ-Lite-2.0/' : "./",
     server: {
         port: 8080
     },


### PR DESCRIPTION
此修改允许app部署在子目录形如 `https://a.b.com/sql/` 下。

参见：https://cn.vitejs.dev/guide/build.html#relative-base

## Summary by Sourcery

部署：
- 容許將應用程式部署喺子目錄，例如 `https://a.b.com/sql/`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Deployment:
- Allow deploying the application under a subdirectory, such as `https://a.b.com/sql/` .

</details>