### PR TITLE
更—— 好的群组显示和消息通知

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -30,8 +30,8 @@ win:
 # macOS 配置
 mac:
     target:
-        - { target: dmg, arch: x64 }
         - { target: dmg, arch: arm64 }
+        - { target: dmg, arch: x64 }
     entitlementsInherit: build/entitlements.mac.plist
     icon: build/icon-client-mac.icns
     darkModeSupport: true
@@ -55,14 +55,14 @@ linux:
         - { target: tar.gz, arch: arm64 }
     maintainer: Stapx Steve [林槐]
     vendor: Stapxs Steve Team
-    synopsis: 一个兼容 OneBot 的非官方网页版 QQ 客户端。
+    synopsis: 一个兼容 OneBot 协议的非官方 QQ 全平台客户端实现。
     category: Network
     mimeTypes: [ application/x-stapxs-qq-lite ]
     desktop:
         Type: Application
         Name: Stapxs QQ Lite
         GenericName: Stapxs QQ Lite Electron 客户端
-        Comment: 一个兼容 OneBot 的非官方网页版 QQ 客户端。
+        Comment: 一个兼容 OneBot 协议的非官方 QQ 全平台客户端实现。
         Terminal: false
         Category: Network
         Icon: stapxs-qq-lite

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "stapxs-qq-lite",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "private": false,
     "author": "Stapx Steve [林槐]",
-    "description": "一个兼容 OneBot 协议的非官方 QQ 全平台客户端实现",
+    "description": "一个兼容 OneBot 协议的非官方 QQ 全平台客户端实现。",
     "homepage": "http://github.com/Stapxs/Stapxs-QQ-Lite-2.0",
     "license": "Apache-2.0",
     "main": "./out/main/index.js",

--- a/scripts/clear-dist.sh
+++ b/scripts/clear-dist.sh
@@ -1,11 +1,18 @@
 dirs=(
+    # web
     "dist"
-    "dist_electron"
-    "dist_capacitor"
+    "stats.html"
+    # electron
     "out"
+    "dist_electron"
+    # capacitor
+    "dist_capacitor"
+    # npx
     "ssqq.npx-web-quick-start/bin"
     "ssqq.npx-web-quick-start/node_modules"
-    "stats.html"
+    # android
+    "src/mobile/android/app/release"
+    "src/mobile/android/app/debug"
 )
 
 for dir in ${dirs[@]}; do

--- a/src/mobile/android/app/app.properties
+++ b/src/mobile/android/app/app.properties
@@ -1,2 +1,2 @@
-versionName=3.0.5
-versionCode=3000005
+versionName=3.0.6
+versionCode=3000006

--- a/src/mobile/ios/App/App/Info.plist
+++ b/src/mobile/ios/App/App/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.0.5</string>
+    <string>3.0.6</string>
     <key>CFBundleVersion</key>
-    <string>3.0.5</string>
+    <string>3.0.6</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>UILaunchStoryboardName</key>

--- a/src/mobile/ios/App/Settings.bundle/Root.plist
+++ b/src/mobile/ios/App/Settings.bundle/Root.plist
@@ -24,7 +24,7 @@
         <key>Key</key>
         <string>version</string>
         <key>DefaultValue</key>
-        <string>3.0.5</string>
+        <string>3.0.6</string>
         <key>IsSecure</key>
         <false/>
         <key>KeyboardType</key>

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -290,8 +290,11 @@ export default defineComponent({
     },
     mounted() {
         const logger = new Logger()
-        window.moYu = () => {
-            return 'undefined'
+        window.moYu = () => { return '\x75\x6e\x64\x65\x66\x69\x6e\x65\x64' }
+        window.onbeforeunload = () => {
+            if (runtimeData.tags.isElectron) {
+                Connector.close()
+            }
         }
         // 页面加载完成后
         window.onload = async () => {

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -652,8 +652,6 @@ export default defineComponent({
                     'getGroupMemberList',
                 )
             }
-            // 刷新系统消息
-            Connector.send('get_system_msg', {}, 'getSystemMsg')
 
             // 清理通知
             if (runtimeData.plantform.reader) {

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -95,7 +95,12 @@
                                 <button id="connect_btn" class="ss-button" type="submit"
                                     :disabled="loginInfo.creating"
                                     @mousemove="afd">
-                                    {{ loginInfo.creating ? $t('连接中') : $t('连接') }}
+                                    <template v-if="!loginInfo.creating">
+                                        {{ $t('连接') }}
+                                    </template>
+                                    <template v-else>
+                                        <font-awesome-icon :icon="['fas', 'spinner']" spin />
+                                    </template>
                                 </button>
                             </form>
                             <a href="https://github.com/Stapxs/Stapxs-QQ-Lite-2.0#%E5%BF%AB%E9%80%9F%E4%BD%BF%E7%94%A8"

--- a/src/renderer/src/assets/css/append/append_new.css
+++ b/src/renderer/src/assets/css/append/append_new.css
@@ -286,11 +286,11 @@ body {
     font-size: 0.7rem;
 }
 .contributors-card > div > div {
-    min-width: 25px;
-    min-height: 25px;
-    margin-top: 5px;
-    margin-bottom: 5px;
+    min-width: calc(20% - 10px);
+    aspect-ratio: 1;
+    margin: 5px;
 }
+
 .contributors-card {
     width: calc(100% - 20px);
     min-height: 0;

--- a/src/renderer/src/assets/css/options.css
+++ b/src/renderer/src/assets/css/options.css
@@ -158,25 +158,25 @@
     flex-wrap: wrap;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    width: 100%;
 }
 .contributors-card > div > div {
+    min-width: calc(20% - 20px);
+    aspect-ratio: 1;
+    margin: 10px;
     background-size: 100%;
     border-radius: 35px;
-    margin-right: 10px;
-    min-height: 35px;
-    min-width: 35px;
-    margin-top: 10px;
-    margin-bottom: 10px;
     cursor: pointer;
 }
 .contributors-card > div > div.me {
     outline: 2px solid var(--color-main);
     border: 1px solid var(--color-card-1);
+    box-sizing: border-box;
 }
 .contributors-card > div > div.super-thanks {
     outline: 2px dashed var(--color-main);
     border: 1px solid var(--color-card-1);
+    box-sizing: border-box;
 }
 
 .opt-tab {

--- a/src/renderer/src/assets/l10n/zh-CAT.po
+++ b/src/renderer/src/assets/l10n/zh-CAT.po
@@ -119,12 +119,6 @@ msgstr "喵喵喵喵喵！"
 msgid "开发者选项"
 msgstr "工程喵选项"
 
-msgid "通知所有新消息"
-msgstr "通知左右新喵喵"
-
-msgid "让暴风雨来得更猛烈些吧！"
-msgstr "让喵喵风暴来得更猛烈些吧！"
-
 msgid "好嘛 …… 不烦你 ……"
 msgstr "不可以喵喵！"
 

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -834,7 +834,7 @@ msgstr ""
 msgid "确定要退出群聊吗？"
 msgstr ""
 
-msgid "留言"
+msgid "留言："
 msgstr ""
 
 msgid "请求加为好友"

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -978,12 +978,6 @@ msgstr ""
 msgid "群收纳盒"
 msgstr ""
 
-msgid "关闭群收纳盒"
-msgstr ""
-
-msgid "你也不想点来点去找群聊和私聊吧"
-msgstr ""
-
 msgid "来自局域网的服务"
 msgstr ""
 

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -978,6 +978,12 @@ msgstr ""
 msgid "群收纳盒"
 msgstr ""
 
+msgid "关闭群收纳盒"
+msgstr ""
+
+msgid "你也不想点来点去找群聊和私聊吧"
+msgstr ""
+
 msgid "来自局域网的服务"
 msgstr ""
 

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -246,10 +246,10 @@ msgstr ""
 msgid "ReferenceError: moYu is not defined"
 msgstr ""
 
-msgid "通知所有新消息"
+msgid "关闭群收纳盒"
 msgstr ""
 
-msgid "让暴风雨来得更猛烈些吧！"
+msgid "全都放出来！全都放出来！"
 msgstr ""
 
 msgid "禁用通知"
@@ -991,10 +991,10 @@ msgid "别划了别划了被看见了啦"
 msgstr ""
 
 msgid "[有人@你]"
-msgstr ""
+msgstr "[有人{'@'}你]"
 
 msgid "[@全体]"
-msgstr ""
+msgstr "[{'@'}全体]"
 
 msgid "[特別关心]"
 msgstr ""

--- a/src/renderer/src/assets/l10n/zh-TW.po
+++ b/src/renderer/src/assets/l10n/zh-TW.po
@@ -834,7 +834,7 @@ msgstr ""
 msgid "确定要退出群聊吗？"
 msgstr ""
 
-msgid "留言"
+msgid "留言："
 msgstr ""
 
 msgid "请求加为好友"

--- a/src/renderer/src/assets/l10n/zh-TW.po
+++ b/src/renderer/src/assets/l10n/zh-TW.po
@@ -246,11 +246,11 @@ msgstr "基本"
 msgid "ReferenceError: moYu is not defined"
 msgstr "ReferenceError: moYu is not defined"
 
-msgid "通知所有新消息"
-msgstr "通知所有新訊息"
+msgid "关闭群收纳盒"
+msgstr ""
 
-msgid "让暴风雨来得更猛烈些吧！"
-msgstr "讓暴風雨來得更猛烈些吧！"
+msgid "全都放出来！全都放出来！"
+msgstr ""
 
 msgid "禁用通知"
 msgstr "停用通知"

--- a/src/renderer/src/assets/l10n/zh-YUE.po
+++ b/src/renderer/src/assets/l10n/zh-YUE.po
@@ -834,7 +834,7 @@ msgstr ""
 msgid "确定要退出群聊吗？"
 msgstr ""
 
-msgid "留言"
+msgid "留言："
 msgstr ""
 
 msgid "请求加为好友"

--- a/src/renderer/src/assets/l10n/zh-YUE.po
+++ b/src/renderer/src/assets/l10n/zh-YUE.po
@@ -246,11 +246,11 @@ msgstr "Info"
 msgid "ReferenceError: moYu is not defined"
 msgstr "小心老闆叫你 OT debug 囉"
 
-msgid "通知所有新消息"
-msgstr "通知所有訊息"
+msgid "关闭群收纳盒"
+msgstr ""
 
-msgid "让暴风雨来得更猛烈些吧！"
-msgstr "電 腦 大 爆 炸！！！"
+msgid "全都放出来！全都放出来！"
+msgstr ""
 
 msgid "禁用通知"
 msgstr "停用通知"

--- a/src/renderer/src/function/connect.ts
+++ b/src/renderer/src/function/connect.ts
@@ -77,9 +77,9 @@ export class Connector {
             sse.onmessage = (e) => {
                 this.onmessage(e.data)
             }
-            sse.onerror = (e) => {
+            sse.onerror = () => {
                 login.creating = false
-                popInfo.add(PopType.ERR, $t('连接失败') + ': ' + e.type, false)
+                popInfo.add(PopType.ERR, $t('连接不稳定'))
                 return
             }
             return
@@ -209,11 +209,13 @@ export class Connector {
                 break
             }
             default: {
+                login.creating = false
                 popInfo.add(PopType.ERR, $t('连接失败') + ': ' + code, false)
             }
         }
 
         logger.error(null, $t('连接失败') + ': ' + code)
+        login.creating = false
         login.status = false
     }
 

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -1730,14 +1730,15 @@ function newMsg(_: string, data: any) {
             })
         }
 
-        // ( 如果是群组消息 && 群组没有开启通知 && 不是置顶的 ) 这种情况下将群消息添加到群通知列表中
-        if (getGroup.length != 1 && data.message_type === 'group' && !isGroupNotice) {
+        // ( 如果 没有关闭群收纳盒 && 是群组消息 && 群组没有开启通知 && 不是置顶的 ) 这种情况下将群消息添加到群通知列表中
+        const close_group_assist = runtimeData.sysConfig.close_group_assist
+        if (!close_group_assist && getGroup.length != 1 && data.message_type === 'group' && !isGroupNotice) {
             const getList = runtimeData.userList.filter((item) => {
                 return item.group_id === id
             })
-            if(getList.length === 1) {
+            if (getList.length === 1) {
                 const showGroup = getList[0]
-                if(!showGroup.always_top) {
+                if (!showGroup.always_top) {
                     const formatted = formatMessageData(data, true)
                     Object.assign(showGroup, formatted)
                     runtimeData.groupAssistList.push(showGroup)

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -1730,7 +1730,7 @@ function newMsg(_: string, data: any) {
             })
         }
 
-        // ( 如果 没有关闭群收纳盒 && 是群组消息 && 群组没有开启通知 && 不是置顶的 ) 这种情况下将群消息添加到群通知列表中
+        // ( 如果 是群组消息 && 群组没有开启通知 && 不是置顶的 ) 这种情况下将群消息添加到群通知列表中
         const close_group_assist = runtimeData.sysConfig.close_group_assist
         if (!close_group_assist && getGroup.length != 1 && data.message_type === 'group' && !isGroupNotice) {
             const getList = runtimeData.userList.filter((item) => {

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -908,13 +908,6 @@ const msgFunctons = {
     },
 
     /**
-     * 保存系统消息
-     */
-    getSystemMsg: (_: string, msg: { [key: string]: any }) => {
-        runtimeData.systemNoticesList = msg.data
-    },
-
-    /**
      * 获取发送的消息（消息发送后处理）
      * @deprecated 功能已被遗弃，暂时保留方法
      */

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -1644,9 +1644,11 @@ function newMsg(_: string, data: any) {
                 runtimeData.onMsgList[index].time = getViewTime(
                     Number(data.time),
                 )
-                if(data.atme) { runtimeData.onMsgList[index].highlight = $t('[有人@你]') }
-                if(data.atall) { runtimeData.onMsgList[index].highlight = $t('[@全体]') }
-                if(isImportant) { runtimeData.onMsgList[index].highlight = $t('[特別关心]') }
+                if(id != showId) {
+                    if(data.atme) { runtimeData.onMsgList[index].highlight = $t('[有人@你]') }
+                    if(data.atall) { runtimeData.onMsgList[index].highlight = $t('[@全体]') }
+                    if(isImportant) { runtimeData.onMsgList[index].highlight = $t('[特別关心]') }
+                }
 
                 // 重新排序列表
                 const newList = orderOnMsgList(runtimeData.onMsgList)
@@ -1767,7 +1769,8 @@ function newMsg(_: string, data: any) {
                             const formatted = formatMessageData(data, data.message_type === 'group')
                             Object.assign(showUser, formatted)
                             runtimeData.onMsgList.push(showUser)
-                        } else {
+                        } else if(id != showId) {
+                            // 显示特殊高亮提醒
                             const showUser = getOnMsg[0]
                             if(data.atme) { showUser.highlight = $t('[有人@你]') }
                             if(data.atall) { showUser.highlight = $t('[@全体]') }

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -1514,6 +1514,8 @@ function newMsg(_: string, data: any) {
                 runtimeData.messageList[fakeIndex].fake_msg = undefined
                 runtimeData.messageList[fakeIndex].revoke = false
             }
+            // 移除最顶端的一条消息以被动刷新整个列表
+            runtimeData.messageList.shift()
             return
         }
 
@@ -1677,12 +1679,13 @@ function newMsg(_: string, data: any) {
 
         // 通知判定 ============================================
         // eslint-disable-next-line max-len
-        // (发送者不是自己 && (在特别关心列表里 || 发送者不是群组 || 群组 AT || 群组 AT 全体 || 群组开启了通知)) 这些情况需要进行新消息处理
+        // (发送者不是自己 && (在特别关心列表里 || 发送者不是群组 || 开启了群组通知模式 || 群组 AT || 群组 AT 全体 || 群组开启了通知)) 这些情况需要进行新消息处理
         if (
             sender != loginId &&
             sender != 0 &&
             (isImportant ||
                 data.message_type !== 'group' ||
+                runtimeData.sysConfig.group_notice_type != 'none' ||
                 data.atme ||
                 data.atall ||
                 isGroupNotice)
@@ -1695,6 +1698,7 @@ function newMsg(_: string, data: any) {
             })
             // (发送者没有被打开 || 窗口没有焦点 || 窗口被最小化 || 在特别关心列表里) 这些情况需要进行消息通知
             if (
+                runtimeData.sysConfig.group_notice_type == 'all' ||
                 id !== showId ||
                 !document.hasFocus() ||
                 document.hidden ||

--- a/src/renderer/src/function/option.ts
+++ b/src/renderer/src/function/option.ts
@@ -27,6 +27,7 @@ import {
     getTrueLang,
 } from '@renderer/function/utils/systemUtil'
 import { orderOnMsgList } from './utils/msgUtil'
+import OptionFun from './option'
 
 let cacheConfigs: { [key: string]: any }
 
@@ -62,13 +63,39 @@ const configFunction: { [key: string]: (value: any) => void } = {
     bubble_sort_user: clearGroupAssist,
 }
 
-function clearGroupAssist() {
-    // 如果 GroupAssistList 里有东西，把它们全部挪到 OnMsgList 里然后清空
-    if (runtimeData.groupAssistList.length > 0) {
-        runtimeData.onMsgList.push(...runtimeData.groupAssistList)
-        runtimeData.groupAssistList = []
-        const newList = orderOnMsgList(runtimeData.onMsgList)
-        runtimeData.onMsgList = newList
+function clearGroupAssist(value: boolean) {
+    if(value) {
+        // 如果 GroupAssistList 里有东西，把它们全部挪到 OnMsgList 里然后清空
+        if (runtimeData.groupAssistList.length > 0) {
+            runtimeData.onMsgList.push(...runtimeData.groupAssistList)
+            runtimeData.groupAssistList = []
+            const newList = orderOnMsgList(runtimeData.onMsgList)
+            runtimeData.onMsgList = newList
+        }
+    } else {
+        // 将 onMsgList 中的非置顶、没有开启消息通知的群挪到 GroupAssistList 里
+        const noticeInfo = OptionFun.get('notice_group') ?? {}
+        const noticeGroupIdList = noticeInfo[runtimeData.loginInfo.uin]
+
+        const notTopGroupIdList = runtimeData.onMsgList.filter((item) => {
+            return !item.always_top && item.group_id
+        }).map((item) => {
+            return item.group_id
+        })
+
+        const groupAssistList = notTopGroupIdList.filter((item) => {
+            return !noticeGroupIdList.includes(item)
+        })
+
+        const newList = runtimeData.onMsgList.filter((item) => {
+            return groupAssistList.includes(item.group_id)
+        })
+        // 删除 onMsgList 中的这些群
+        runtimeData.onMsgList = runtimeData.onMsgList.filter((item) => {
+            return !groupAssistList.includes(item.group_id)
+        })
+        const sortedList = orderOnMsgList(newList)
+        runtimeData.groupAssistList = sortedList
     }
 }
 

--- a/src/renderer/src/function/option.ts
+++ b/src/renderer/src/function/option.ts
@@ -44,6 +44,7 @@ const optDefault: { [key: string]: any } = {
     chat_background_blur: 0,
     msg_type: 2,
     store_face: '[]',
+    group_notice_type: 'none',
 }
 
 // =============== 设置项事件 ===============

--- a/src/renderer/src/function/option.ts
+++ b/src/renderer/src/function/option.ts
@@ -26,6 +26,7 @@ import {
     getPortableFileLang,
     getTrueLang,
 } from '@renderer/function/utils/systemUtil'
+import { orderOnMsgList } from './utils/msgUtil'
 
 let cacheConfigs: { [key: string]: any }
 
@@ -58,6 +59,17 @@ const configFunction: { [key: string]: (value: any) => void } = {
     opt_revolve: viewRevolve,
     opt_always_top: viewAlwaysTop,
     opt_fast_animation: updateFarstAnimation,
+    bubble_sort_user: clearGroupAssist,
+}
+
+function clearGroupAssist() {
+    // 如果 GroupAssistList 里有东西，把它们全部挪到 OnMsgList 里然后清空
+    if (runtimeData.groupAssistList.length > 0) {
+        runtimeData.onMsgList.push(...runtimeData.groupAssistList)
+        runtimeData.groupAssistList = []
+        const newList = orderOnMsgList(runtimeData.onMsgList)
+        runtimeData.onMsgList = newList
+    }
 }
 
 function updateFarstAnimation(value: boolean) {

--- a/src/renderer/src/function/utils/appUtil.ts
+++ b/src/renderer/src/function/utils/appUtil.ts
@@ -581,7 +581,11 @@ export async function loadMobile() {
                 case 'onopen': Connector.onopen(login.address, login.token); break
                 case 'onmessage': Connector.onmessage(data.data); break
                 case 'onclose': Connector.onclose(msg.code, msg.message, login.address, login.token); break
-                case 'onerror': popInfo.add(PopType.ERR, $t('连接失败') + ': ' + msg.type, false); break
+                case 'onerror': {
+                    login.creating = false
+                    popInfo.add(PopType.ERR, $t('连接失败') + ': ' + msg.type, false);
+                    break
+                }
                 case 'onServiceFound': setQuickLogin(msg.address, msg.port); break
                 default: break
             }

--- a/src/renderer/src/function/utils/appUtil.ts
+++ b/src/renderer/src/function/utils/appUtil.ts
@@ -173,8 +173,6 @@ export function reloadUsers() {
         }
         Connector.send(friendName, {}, 'getFriendList')
         Connector.send(groupName, {}, 'getGroupList')
-        // 获取系统消息
-        Connector.send('get_system_msg', {}, 'getSystemMsg')
     }
 }
 

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -1367,10 +1367,9 @@
                         if (
                             runtimeData.chatInfo.show.type != 'group' ||
                             data.sender.user_id === runtimeData.loginInfo.uin ||
-                            runtimeData.chatInfo.info.me_info.role ===
-                                'member' ||
+                            runtimeData.chatInfo.info.me_info.role === 'member' ||
                             selectUserType == 'owner' ||
-                            selectUserType == 'admin'
+                            (selectUserType == 'admin' && runtimeData.chatInfo.info.me_info.role != 'owner')
                         ) {
                             // 自己、私聊或者没有权限的时候不显示移除
                             this.tags.menuDisplay.remove = false

--- a/src/renderer/src/pages/Messages.vue
+++ b/src/renderer/src/pages/Messages.vue
@@ -18,7 +18,7 @@
             ">
             <div>
                 <div class="base only">
-                    <span v-if="showGroupAssist" style="cursor: pointer;"
+                    <span v-if="!runtimeData.sysConfig.close_group_assist && showGroupAssist" style="cursor: pointer;"
                         @click="showGroupAssist = !showGroupAssist">
                         <font-awesome-icon style="margin-right: 5px;" :icon="['fas', 'angle-left']" />
                         {{ $t('群收纳盒') }}
@@ -30,7 +30,7 @@
                         @click="cleanList" />
                 </div>
                 <div class="small">
-                    <span v-if="showGroupAssist" style="cursor: pointer;">
+                    <span v-if="!runtimeData.sysConfig.close_group_assist && showGroupAssist" style="cursor: pointer;">
                         {{ $t('群收纳盒') }}
                     </span>
                     <span v-else>{{
@@ -105,7 +105,8 @@
                     @click="systemNoticeClick" />
                 <!--- 群组消息 -->
                 <FriendBody
-                    v-if="runtimeData.groupAssistList &&
+                    v-if="!runtimeData.sysConfig.close_group_assist && 
+                        runtimeData.groupAssistList &&
                         runtimeData.groupAssistList.length > 0 &&
                         !showGroupAssist"
                     key="inMessage--10001"
@@ -259,8 +260,11 @@
                         ).toString(),
                     )
                 }
+
+                const close_group_assist = runtimeData.sysConfig.close_group_assist
+
                 // 判断一下群是否应该在群收纳盒内
-                if(!this.showGroupAssist) {
+                if (!close_group_assist && !this.showGroupAssist) {
                     // 如果这个群没有开启通知并且不是置顶的，就移动到群收纳盒
                     if (
                         data.group_id &&
@@ -279,7 +283,7 @@
                             return data == get
                         })
                         runtimeData.onMsgList.splice(index, 1)
-                        if(!has) {
+                        if (!has) {
                             runtimeData.groupAssistList.push(data)
                         }
                         // 打开群收纳盒
@@ -429,7 +433,10 @@
                                     return item == get
                                 },
                             )
-                            if (index >= 0 && !item.always_top) {
+
+                            const close_group_assist = runtimeData.sysConfig.close_group_assist
+
+                            if (!close_group_assist && index >= 0 && !item.always_top) {
                                 runtimeData.onMsgList.splice(index, 1)
                                 runtimeData.groupAssistList.push(item)
                             }

--- a/src/renderer/src/pages/Messages.vue
+++ b/src/renderer/src/pages/Messages.vue
@@ -18,7 +18,7 @@
             ">
             <div>
                 <div class="base only">
-                    <span v-if="!runtimeData.sysConfig.notice_all && showGroupAssist" style="cursor: pointer;"
+                    <span v-if="showGroupAssist" style="cursor: pointer;"
                         @click="showGroupAssist = !showGroupAssist">
                         <font-awesome-icon style="margin-right: 5px;" :icon="['fas', 'angle-left']" />
                         {{ $t('群收纳盒') }}
@@ -30,7 +30,7 @@
                         @click="cleanList" />
                 </div>
                 <div class="small">
-                    <span v-if="!runtimeData.sysConfig.notice_all && showGroupAssist" style="cursor: pointer;">
+                    <span v-if="showGroupAssist" style="cursor: pointer;">
                         {{ $t('群收纳盒') }}
                     </span>
                     <span v-else>{{
@@ -105,8 +105,7 @@
                     @click="systemNoticeClick" />
                 <!--- 群组消息 -->
                 <FriendBody
-                    v-if="!runtimeData.sysConfig.notice_all && 
-                        runtimeData.groupAssistList &&
+                    v-if="runtimeData.groupAssistList &&
                         runtimeData.groupAssistList.length > 0 &&
                         !showGroupAssist"
                     key="inMessage--10001"
@@ -261,10 +260,10 @@
                     )
                 }
 
-                const close_group_assist = runtimeData.sysConfig.notice_all
-
                 // 判断一下群是否应该在群收纳盒内
-                if (!close_group_assist && !this.showGroupAssist) {
+                if (!this.showGroupAssist &&
+                    !runtimeData.sysConfig.bubble_sort_user
+                ) {
                     // 如果这个群没有开启通知并且不是置顶的，就移动到群收纳盒
                     if (
                         data.group_id &&
@@ -428,17 +427,17 @@
                             }
                             Option.save('notice_group', noticeInfo)
                             // 如果它在 onMsgList 里面，移到 groupAssistList
-                            const index = runtimeData.onMsgList.findIndex(
-                                (get) => {
-                                    return item == get
-                                },
-                            )
+                            if(!runtimeData.sysConfig.bubble_sort_user) {
+                                const index = runtimeData.onMsgList.findIndex(
+                                    (get) => {
+                                        return item == get
+                                    },
+                                )
 
-                            const close_group_assist = runtimeData.sysConfig.notice_all
-
-                            if (!close_group_assist && index >= 0 && !item.always_top) {
-                                runtimeData.onMsgList.splice(index, 1)
-                                runtimeData.groupAssistList.push(item)
+                                if (index >= 0 && !item.always_top) {
+                                    runtimeData.onMsgList.splice(index, 1)
+                                    runtimeData.groupAssistList.push(item)
+                                }
                             }
                             break
                         }

--- a/src/renderer/src/pages/Messages.vue
+++ b/src/renderer/src/pages/Messages.vue
@@ -18,7 +18,7 @@
             ">
             <div>
                 <div class="base only">
-                    <span v-if="!runtimeData.sysConfig.close_group_assist && showGroupAssist" style="cursor: pointer;"
+                    <span v-if="!runtimeData.sysConfig.notice_all && showGroupAssist" style="cursor: pointer;"
                         @click="showGroupAssist = !showGroupAssist">
                         <font-awesome-icon style="margin-right: 5px;" :icon="['fas', 'angle-left']" />
                         {{ $t('群收纳盒') }}
@@ -30,7 +30,7 @@
                         @click="cleanList" />
                 </div>
                 <div class="small">
-                    <span v-if="!runtimeData.sysConfig.close_group_assist && showGroupAssist" style="cursor: pointer;">
+                    <span v-if="!runtimeData.sysConfig.notice_all && showGroupAssist" style="cursor: pointer;">
                         {{ $t('群收纳盒') }}
                     </span>
                     <span v-else>{{
@@ -105,7 +105,7 @@
                     @click="systemNoticeClick" />
                 <!--- 群组消息 -->
                 <FriendBody
-                    v-if="!runtimeData.sysConfig.close_group_assist && 
+                    v-if="!runtimeData.sysConfig.notice_all && 
                         runtimeData.groupAssistList &&
                         runtimeData.groupAssistList.length > 0 &&
                         !showGroupAssist"
@@ -261,7 +261,7 @@
                     )
                 }
 
-                const close_group_assist = runtimeData.sysConfig.close_group_assist
+                const close_group_assist = runtimeData.sysConfig.notice_all
 
                 // 判断一下群是否应该在群收纳盒内
                 if (!close_group_assist && !this.showGroupAssist) {
@@ -434,7 +434,7 @@
                                 },
                             )
 
-                            const close_group_assist = runtimeData.sysConfig.close_group_assist
+                            const close_group_assist = runtimeData.sysConfig.notice_all
 
                             if (!close_group_assist && index >= 0 && !item.always_top) {
                                 runtimeData.onMsgList.splice(index, 1)

--- a/src/renderer/src/pages/Messages.vue
+++ b/src/renderer/src/pages/Messages.vue
@@ -496,6 +496,28 @@
                 }
                 // 为消息列表内的对象刷新置顶标志
                 item.always_top = value
+                // 刷新群收纳盒
+                if(item.group_id && !runtimeData.sysConfig.bubble_sort_user) {
+                    if(value) {
+                        const index = runtimeData.groupAssistList.findIndex((get) => {
+                            return item == get
+                        })
+                        if (index >= 0) {
+                            runtimeData.groupAssistList.splice(index, 1)
+                        }
+                        runtimeData.onMsgList.push(item)
+                        this.showGroupAssist = false
+                    } else {
+                        const index = runtimeData.onMsgList.findIndex((get) => {
+                            return item == get
+                        })
+                        if (index >= 0) {
+                            runtimeData.onMsgList.splice(index, 1)
+                            runtimeData.groupAssistList.push(item)
+                        }
+                        this.showGroupAssist = true
+                    }
+                }
                 // 重新排序列表
                 const newList = orderOnMsgList(runtimeData.onMsgList)
                 runtimeData.onMsgList = newList

--- a/src/renderer/src/pages/chat-view/SystemNotice.vue
+++ b/src/renderer/src/pages/chat-view/SystemNotice.vue
@@ -43,7 +43,7 @@
                                     minute: 'numeric',
                                 }).format(new Date(notice.time * 1000))
                             }}</a>
-                            <a>{{ $t('留言') + notice.comment }}</a>
+                            <a>{{ $t('留言：') + notice.comment }}</a>
                         </div>
                     </div>
                     <div>
@@ -82,7 +82,7 @@
                                     minute: 'numeric',
                                 }).format(new Date(notice.time * 1000))
                             }}</a>
-                            <a>{{ $t('留言') + notice.comment }}</a>
+                            <a>{{ $t('留言：') + notice.comment }}</a>
                         </div>
                     </div>
                     <div>

--- a/src/renderer/src/pages/options/OptFunction.vue
+++ b/src/renderer/src/pages/options/OptFunction.vue
@@ -50,6 +50,26 @@
         <div class="ss-card">
             <header>{{ $t('聊天选项') }}</header>
             <div class="opt-item">
+                <font-awesome-icon :icon="['fas', 'user-group']" />
+                <div>
+                    <span>{{ $t('关闭群收纳盒') }}</span>
+                    <span>{{ $t('你也不想点来点去找群聊和私聊吧') }}</span>
+                </div>
+                <label
+                    v-if="ndt < 3"
+                    class="ss-switch">
+                    <input
+                        v-model="runtimeData.sysConfig.close_group_assist"
+                        type="checkbox"
+                        name="close_group_assist"
+                        @change="save">
+                    <div>
+                        <div />
+                    </div>
+                </label>
+            </div>
+
+            <div class="opt-item">
                 <font-awesome-icon :icon="['fas', 'box-archive']" />
                 <div>
                     <span>{{ $t('消息防撤回') }}</span>

--- a/src/renderer/src/pages/options/OptFunction.vue
+++ b/src/renderer/src/pages/options/OptFunction.vue
@@ -44,6 +44,28 @@
                     </div>
                 </label>
             </div>
+            <div v-if="runtimeData.sysConfig.bubble_sort_user" class="opt-item">
+                <font-awesome-icon :icon="['fas', 'user-group']" />
+                <div>
+                    <span>{{ $t('群消息通知方式') }}</span>
+                    <span>{{ $t('重要消息将始终发起应用内通知和系统通知') }}</span>
+                </div>
+                <select
+                    v-model="runtimeData.sysConfig.group_notice_type"
+                    name="group_notice_type"
+                    title="group_notice_type"
+                    @change="save">
+                    <option value="none">
+                        {{ $t('不通知（默认）') }}
+                    </option>
+                    <option value="inner">
+                        {{ $t('仅应用内通知') }}
+                    </option>
+                    <option value="all">
+                        {{ $t('应用内通知和系统通知') }}
+                    </option>
+                </select>
+            </div>
         </div>
         <div class="ss-card">
             <header>{{ $t('聊天选项') }}</header>

--- a/src/renderer/src/pages/options/OptFunction.vue
+++ b/src/renderer/src/pages/options/OptFunction.vue
@@ -27,19 +27,17 @@
                     </div>
                 </label>
             </div>
-            <div
-                v-if="!runtimeData.sysConfig.close_notice"
-                class="opt-item">
-                <font-awesome-icon :icon="['fas', 'bolt']" />
+            <div class="opt-item">
+                <font-awesome-icon :icon="['fas', 'box-open']" />
                 <div>
-                    <span>{{ $t('通知所有新消息') }}</span>
-                    <span>{{ $t('让暴风雨来得更猛烈些吧！') }}</span>
+                    <span>{{ $t('关闭群收纳盒') }}</span>
+                    <span>{{ $t('全都放出来！全都放出来！') }}</span>
                 </div>
                 <label class="ss-switch">
                     <input
-                        v-model="runtimeData.sysConfig.notice_all"
+                        v-model="runtimeData.sysConfig.bubble_sort_user"
                         type="checkbox"
-                        name="notice_all"
+                        name="bubble_sort_user"
                         @change="save">
                     <div>
                         <div />

--- a/src/renderer/src/pages/options/OptFunction.vue
+++ b/src/renderer/src/pages/options/OptFunction.vue
@@ -50,26 +50,6 @@
         <div class="ss-card">
             <header>{{ $t('聊天选项') }}</header>
             <div class="opt-item">
-                <font-awesome-icon :icon="['fas', 'user-group']" />
-                <div>
-                    <span>{{ $t('关闭群收纳盒') }}</span>
-                    <span>{{ $t('你也不想点来点去找群聊和私聊吧') }}</span>
-                </div>
-                <label
-                    v-if="ndt < 3"
-                    class="ss-switch">
-                    <input
-                        v-model="runtimeData.sysConfig.close_group_assist"
-                        type="checkbox"
-                        name="close_group_assist"
-                        @change="save">
-                    <div>
-                        <div />
-                    </div>
-                </label>
-            </div>
-
-            <div class="opt-item">
                 <font-awesome-icon :icon="['fas', 'box-archive']" />
                 <div>
                     <span>{{ $t('消息防撤回') }}</span>


### PR DESCRIPTION
#### 更—— 好的群组显示和消息通知

✨ 更完善的群通知设置 <- #185
✨ 现在你可以关闭群收纳盒，使群消息也全部显示在消息列表中 <- #185
🐛 修正通知面板显示异常的问题 <- #194
🐛 新发出的消息无法被正常预览 <- #188
🐛 修正了连接失败未重置加载中提示的问题
🐛 修正了群主没法踢管理员的问题 <- #189
🐛 修正 at 你、at 全体文本 i18n 异常的问题
🐛 修正消息列表排序刷新不及时的问题
🎨 优化在群消息盒中开启置顶的显示逻辑
🎨 优化中途切换开关群收纳盒的显示逻辑
🎨 调整高亮信息显示逻辑
💩 调整 mac 平台编译顺序便于测试