### PR TITLE
更改了一个依赖: semver-compare -> semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "type": "module",
     "scripts": {
         "capacitor:copy:before": "capacitor-sync-version",
-
         "lint": "eslint . --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts,.vue --fix",
         "update:icon": "npx @capacitor/assets generate --assetPath 'src/mobile/_assets' --iosProject 'src/mobile/ios/App' --androidProject 'src/mobile/android' --android --ios",
         "update:version": "npx @stapxs/capacitor-sync-version android ios",
@@ -34,6 +33,7 @@
         "electron-window-state": "^5.0.3",
         "log4js": "^6.9.1",
         "rollup-plugin-node-polyfills": "^0.2.1",
+        "semver": "^7.7.1",
         "vconsole": "^3.15.1",
         "ws": "^8.18.0"
     },
@@ -61,6 +61,7 @@
         "@stapxs/umami-logger-typescript": "^1.0.12",
         "@types/jsonpath": "^0.2.4",
         "@types/node": "^20.14.8",
+        "@types/semver": "^7.5.8",
         "@untiny/capacitor-safe-area": "^1.0.3",
         "@vitejs/plugin-vue": "^5.0.5",
         "@vue/eslint-config-typescript": "^13.0.0",

--- a/src/renderer/src/function/utils/appUtil.ts
+++ b/src/renderer/src/function/utils/appUtil.ts
@@ -1,7 +1,7 @@
 import app from '@renderer/main'
 import FileDownloader from 'js-file-downloader'
 import option from '@renderer/function/option'
-import cmp from 'semver-compare'
+import semver from 'semver'
 import appInfo from '../../../../../package.json'
 import Umami from '@stapxs/umami-logger-typescript'
 
@@ -745,14 +745,15 @@ function showUpadteLog(data: any) {
     //    如果当前版本小于获取到的版本就是有更新
     //    如果缓存版本小于获取到的版本但是当前版本等于获取到的版本就是更新完成首次启动
     const lastestVersion = data.tag_name.substring(1)
-    if (cmp(appVersion, lastestVersion) == -1) {
+
+    if (semver.lt(appVersion, lastestVersion)) {
         // 有更新
         showReleaseLog(data, false)
     }
     if (
         cacheVersion &&
-        cmp(appVersion, lastestVersion) == 0 &&
-        cmp(cacheVersion, lastestVersion) == -1
+        semver.eq(appVersion, lastestVersion) &&
+        semver.lt(cacheVersion, lastestVersion)
     ) {
         // 更新完成首次启动
         showReleaseLog(data, true)

--- a/src/renderer/src/function/utils/appUtil.ts
+++ b/src/renderer/src/function/utils/appUtil.ts
@@ -744,16 +744,16 @@ function showUpadteLog(data: any) {
     // 这儿有两种情况：
     //    如果当前版本小于获取到的版本就是有更新
     //    如果缓存版本小于获取到的版本但是当前版本等于获取到的版本就是更新完成首次启动
-    const lastestVersion = data.tag_name.substring(1)
+    constlatestVersion = data.tag_name.substring(1)
 
-    if (semver.lt(appVersion, lastestVersion)) {
+    if (semver.lt(appVersion,latestVersion)) {
         // 有更新
         showReleaseLog(data, false)
     }
     if (
         cacheVersion &&
-        semver.eq(appVersion, lastestVersion) &&
-        semver.lt(cacheVersion, lastestVersion)
+        semver.eq(appVersion,latestVersion) &&
+        semver.lt(cacheVersion,latestVersion)
     ) {
         // 更新完成首次启动
         showReleaseLog(data, true)

--- a/ssqq.npx-web-quick-start/package.json
+++ b/ssqq.npx-web-quick-start/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "log4js": "^6.9.1",
     "request": "^2.88.2",
-    "semver-compare": "^1.0.0",
+    "semver" : "^7.7.1",
     "typescript": "^5.6.3",
     "unzipper": "^0.12.3"
   },

--- a/ssqq.npx-web-quick-start/update.ts
+++ b/ssqq.npx-web-quick-start/update.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import cmp from 'semver-compare'
+import semver from 'semver'
 import Logger from 'log4js'
 import request from 'request'
 import unzipper from 'unzipper'
@@ -18,7 +18,7 @@ export function checkUpdate(nowVersion: string) {
         .then(json => {
             const version = json.tag_name.slice(1)
             logger.info(`Stapxs QQ Lite 当前版本: ${version}, 本地版本: ${nowVersion}`)
-            if (cmp(nowVersion, version) === -1) {
+            if (semver.lt(nowVersion, version)) {
                 // 本地版本小于线上版本, 需要更新
                 logger.info('发现新版本, 正在更新...')
                 logger.info(`运行路径: ${process.cwd()}`)


### PR DESCRIPTION
[semver-compare](https://www.npmjs.com/package/semver-compare) 似乎早就跑路了，所以我更改成了[semver](https://www.npmjs.com/package/semver)

semver对语义版本号支持更好一点

semver-compare 会认为 `3.0.6-pre.114514` 和 `3.0.6-pre.1919810` 是一个版本

## Sourcery 嘅摘要

用 `semver` 替換已棄用嘅 `semver-compare` 庫，以確保準確嘅版本比較同埋更好嘅預發佈版本支持。

Bug 修复:
- 修正咗由 `semver-compare` 庫引起嘅唔正確版本比較。
- 修正：`semver-compare` 庫錯誤噉比較預發佈版本，可能會導致唔正確嘅更新行爲。 呢個更改用 `semver` 替換咗佢，`semver` 可以正確噉處理預發佈標識符。

雜務:
- 用 `semver` 替換 `semver-compare` 包，以改進語義版本控制支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the deprecated `semver-compare` library with `semver` to ensure accurate version comparison and better pre-release version support.

Bug Fixes:
- Fix incorrect version comparison caused by the `semver-compare` library.
- Fix: The `semver-compare` library incorrectly compared pre-release versions, potentially leading to incorrect update behavior.  This change replaces it with `semver`, which correctly handles pre-release identifiers.

Chores:
- Replace the `semver-compare` package with `semver` for improved semantic versioning support.

</details>