### PR TITLE
文件文件文件——

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -159,6 +159,12 @@ jobs:
               run: yarn build:win
               env:
                   GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+            # 安装打包依赖（Linux）
+            - name: Install Dependencies for Packaging (Linux)
+              if: matrix.os == 'ubuntu-latest'
+              run: |
+                  sudo apt update
+                  sudo apt install -y libarchive-tools
             # 构建 electron 版本（Linux）
             - name: Build Electron (Linux)
               if: matrix.os == 'ubuntu-latest'

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,7 +21,6 @@ asarUnpack:
 win:
     target:
         - { target: portable, arch: x64 }
-        # - { target: portable, arch: arm64 }
     executableName: Stapxs QQ Lite
     icon: build/icon-client-others.png
     legalTrademarks: Copyright © 2022-2025 Stapx Steve [林槐]
@@ -47,12 +46,10 @@ dmg:
 # Linux 配置
 linux:
     target:
+        - { target: pacman, arch: x64 }
         - { target: AppImage, arch: x64 }
-        - { target: AppImage, arch: arm64 }
         - { target: deb, arch: x64 }
-        - { target: deb, arch: arm64 }
         - { target: tar.gz, arch: x64 }
-        - { target: tar.gz, arch: arm64 }
     maintainer: Stapx Steve [林槐]
     vendor: Stapxs Steve Team
     synopsis: 一个兼容 OneBot 协议的非官方 QQ 全平台客户端实现。

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -49,6 +49,7 @@ linux:
         - { target: pacman, arch: x64 }
         - { target: AppImage, arch: x64 }
         - { target: deb, arch: x64 }
+        - { target: deb, arch: arm64 }
         - { target: tar.gz, arch: x64 }
     maintainer: Stapx Steve [林槐]
     vendor: Stapxs Steve Team

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stapxs-qq-lite",
-    "version": "3.0.6",
+    "version": "3.1.0",
     "private": false,
     "author": "Stapx Steve [林槐]",
     "description": "一个兼容 OneBot 协议的非官方 QQ 全平台客户端实现。",

--- a/src/main/function/ipc.ts
+++ b/src/main/function/ipc.ts
@@ -75,33 +75,6 @@ export function regIpcListener() {
         }
         return null
     })
-    // 代理请求 HTTP
-    // ipcMain.on('sys:requestHttp', (event, args) => {
-    // console.log(args)
-
-    // const cookies = JSON.parse(args.cookies)
-    // console.log(cookies)
-    // const cookieStrs = Object.keys(cookies).map((key) => {
-    //     return key + '=' + cookies[key]
-    // })
-    // console.log(cookieStrs.join('; '))
-    // // 异步请求，不需要立即返回
-    // axios({
-    //     method: args.type,
-    //     url: args.url,
-    //     headers: {
-    //         'Content-Type': 'application/json',
-    //         'Cookie': cookieStrs.join('; '),
-    //     },
-    //     data: args.data
-    // }).then((res) => {
-    //     // res.data
-    //     console.log(res.data)
-    // }).catch((err) => {
-    //     // err
-    //     console.error(err)
-    // })
-    // })
     // 关闭窗口
     ipcMain.on('win:close', () => {
         if (win) win.close()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,7 @@ import Store from 'electron-store'
 import fs from 'fs'
 
 import windowStateKeeper from 'electron-window-state'
-import packageInfo from '../../package.json'
+import packageInfo from '../../package.json' assert { type: 'json' }
 import { regIpcListener } from './function/ipc.ts'
 import { Menu, session, app, protocol, BrowserWindow } from 'electron'
 import { touchBar } from './function/touchbar.ts'

--- a/src/mobile/android/app/app.properties
+++ b/src/mobile/android/app/app.properties
@@ -1,2 +1,2 @@
-versionName=3.0.6
-versionCode=3000006
+versionName=3.1.0
+versionCode=3001000

--- a/src/mobile/ios/App/App/Info.plist
+++ b/src/mobile/ios/App/App/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.0.6</string>
+    <string>3.1.0</string>
     <key>CFBundleVersion</key>
-    <string>3.0.6</string>
+    <string>3.1.0</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>UILaunchStoryboardName</key>

--- a/src/mobile/ios/App/Settings.bundle/Root.plist
+++ b/src/mobile/ios/App/Settings.bundle/Root.plist
@@ -24,7 +24,7 @@
         <key>Key</key>
         <string>version</string>
         <key>DefaultValue</key>
-        <string>3.0.6</string>
+        <string>3.1.0</string>
         <key>IsSecure</key>
         <false/>
         <key>KeyboardType</key>

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -298,11 +298,6 @@ export default defineComponent({
     mounted() {
         const logger = new Logger()
         window.moYu = () => { return '\x75\x6e\x64\x65\x66\x69\x6e\x65\x64' }
-        window.onbeforeunload = () => {
-            if (runtimeData.tags.isElectron) {
-                Connector.close()
-            }
-        }
         // 页面加载完成后
         window.onload = async () => {
             // 初始化全局参数
@@ -490,10 +485,25 @@ export default defineComponent({
                     runtimeData.plantform.reader?.send('sys:flushOnMessage', list)
                 })
             }
+            // 更新标题
+            const titleList = [
+                '也试试 Lcalingua Plus Plus 吧！',
+                '点击阅读《社交功能限制提醒》',
+                '登录失败，Code 45',
+                '你好世界！',
+                '这只是个普通的彩蛋！'
+            ]
+            document.title = titleList[Math.floor(Math.random() * titleList.length)]
+            if(runtimeData.tags.platform == 'web') {
+                document.title = titleList[Math.floor(Math.random() * titleList.length)] + '- Stapxs QQ Lite'
+            }
         }
         // 页面关闭前
         window.onbeforeunload = () => {
             new Notify().clear()
+            if(import.meta.env.DEV) {
+                Connector.close()
+            }
         }
     },
     methods: {

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -176,7 +176,9 @@
                             <font-awesome-icon :icon="['fas', runtimeData.popBoxList[0].svg]" />
                         </div>
                         <a>{{ runtimeData.popBoxList[0].title }}</a>
-                        <font-awesome-icon :icon="['fas', 'xmark']" @click="removePopBox" />
+                        <font-awesome-icon v-show="runtimeData.popBoxList[0].button"
+                            :icon="['fas', 'xmark']"
+                            @click="removePopBox" />
                     </header>
                     <div v-if="runtimeData.popBoxList[0].html" v-html="runtimeData.popBoxList[0].html" />
                     <component :is="runtimeData.popBoxList[0].template" v-else :data="runtimeData.popBoxList[0].data"
@@ -648,7 +650,7 @@ export default defineComponent({
                 // PS：部分功能不返回用户名需要进来查找所以提前获取
                 Connector.send(
                     'get_group_member_list',
-                    { group_id: data.id },
+                    { group_id: data.id, no_cache: true },
                     'getGroupMemberList',
                 )
             }

--- a/src/renderer/src/assets/css/chat.css
+++ b/src/renderer/src/assets/css/chat.css
@@ -808,13 +808,15 @@ input {
     background: var(--color-card-1);
     border-radius: 7px 7px 0 0;
     align-items: center;
-    padding: 15px;
+    padding: 15px 20px;
     margin: -15px;
     display: flex;
 }
 .user-config > div:first-child > img {
     border-radius: 7px;
-    width: 40px;
+    width: 35px;
+    border: 1px solid var(--color-card-2);
+    outline: 2px solid var(--color-main);
 }
 .user-config > div:first-child > svg {
     cursor: pointer;
@@ -828,10 +830,11 @@ input {
     flex: 1;
 }
 .user-config > div:first-child > div > a {
-    font-size: 1rem;
+    font-size: 0.9rem;
 }
 .user-config > div:first-child > div > span {
-    color: var(--color-font-1);
+    color: var(--color-font-2);
+    font-size: 0.8rem;
 }
 .user-config > div:last-child {
     flex: 1;

--- a/src/renderer/src/assets/css/chat.css
+++ b/src/renderer/src/assets/css/chat.css
@@ -788,7 +788,6 @@ input {
     transform: translateY(calc(100% + 20px));
     box-shadow: 0 -3px 3px var(--color-shader);
     background: var(--color-card);
-    height: 70%;
     position: absolute;
     width: calc(100% - 30px);
     margin-left: -15px;

--- a/src/renderer/src/assets/css/chat.css
+++ b/src/renderer/src/assets/css/chat.css
@@ -567,13 +567,14 @@ input {
     width: 100%;
 }
 .card-info-pan-bg {
-    background: var(--color-card-2);
     height: 100%;
     opacity: 0.7;
     width: 100%;
 }
 .chat-info {
+    overflow: hidden;
     margin: 50vh 0 0 50%;
+    box-shadow: 0 0 10px var(--color-shader);
     transform: translate(-50%, -50%);
     flex-direction: column;
     position: absolute;
@@ -735,6 +736,28 @@ input {
 }
 .chat-info-tab-member > div > span {
     color: var(--color-font-2);
+    transition: all .2s;
+    opacity: 1;
+}
+.chat-info-tab-member > div.edit:hover > span {
+    transform: translateX(-10px);
+    opacity: 0;
+}
+.chat-info-tab-member > div > svg {
+    color: var(--color-font-2);
+    transition: all .2s;
+    margin-right: -25px;
+    margin-left: 10px;
+    width: 15px;
+    opacity: 0;
+}
+.chat-info-tab-member > div > svg:hover {
+    color: var(--color-main);
+}
+.chat-info-tab-member > div.edit:hover > svg {
+    margin-right: 5px;
+    display: block;
+    opacity: 1;
 }
 
 .chat-info-tab {
@@ -756,6 +779,77 @@ input {
 }
 .chat-info-tab .tab-body {
     overflow-y: scroll;
+}
+
+.user-config {
+    display: flex;
+    flex-direction: column;
+    transition: all 0.3s;
+    transform: translateY(calc(100% + 20px));
+    box-shadow: 0 -3px 3px var(--color-shader);
+    background: var(--color-card);
+    height: 70%;
+    position: absolute;
+    width: calc(100% - 30px);
+    margin-left: -15px;
+    height: auto;
+    top: 0;
+    bottom: 0;
+    margin-top: 50px;
+}
+.user-config.show {
+    transform: translateY(0);
+}
+.user-config:hover {
+    box-shadow: 0 -3px 3px var(--color-shader) !important;
+}
+
+.user-config > div:first-child {
+    background: var(--color-card-1);
+    border-radius: 7px 7px 0 0;
+    align-items: center;
+    padding: 15px;
+    margin: -15px;
+    display: flex;
+}
+.user-config > div:first-child > img {
+    border-radius: 7px;
+    width: 40px;
+}
+.user-config > div:first-child > svg {
+    cursor: pointer;
+    width: 17px;
+    height: 17px;
+}
+.user-config > div:first-child > div {
+    flex-direction: column;
+    margin-left: 10px;
+    display: flex;
+    flex: 1;
+}
+.user-config > div:first-child > div > a {
+    font-size: 1rem;
+}
+.user-config > div:first-child > div > span {
+    color: var(--color-font-1);
+}
+.user-config > div:last-child {
+    flex: 1;
+    overflow-y: scroll;
+    padding: 0 15px 0 20px;
+    margin-top: 25px;
+}
+.user-config > div:last-child > div:hover {
+    background: var(--color-card-1);
+}
+.user-config > div:last-child > header {
+    font-weight: normal;
+    font-size: 0.9rem;
+    padding: 10px 0 0 0;
+}
+.user-config > div:last-child > div:hover input {
+    background: var(--color-card-2);
+    transition: all 0.3s;
 }
 
 .bulletins {
@@ -915,15 +1009,6 @@ input {
 }
 .group-files > div > div > div > div > span:last-child::after {
     content: '';
-}
-
-.group-files-loader {
-    justify-content: center;
-    display: flex;
-}
-.group-files-loader > svg {
-    color: var(--color-font-1);
-    width: 1rem;
 }
 
 .info-pan-set {

--- a/src/renderer/src/assets/css/msg.css
+++ b/src/renderer/src/assets/css/msg.css
@@ -305,52 +305,49 @@
     align-items: center;
     flex-wrap: wrap;
 }
-.msg-file > svg {
-    color: var(--color-font-1);
-    height: calc(2rem + 10px);
-    margin-right: 20px;
-    margin-left: 10px;
-}
 .msg-file svg {
     color: var(--color-font-1);
 }
 .msg-file.me svg {
     color: var(--color-font-1-r);
 }
-.msg-file > div:nth-child(2) {
+.msg-file > div:nth-child(1) {
     display: flex;
     flex-direction: column;
     flex: 1;
 }
-.msg-file > div:nth-child(2) i {
-    font-size: 0.9rem;
+.msg-file > div:nth-child(1) a {
+    font-size: 0.75rem;
+    display: block;
+    opacity: 0.7;
+}
+.msg-file > div:nth-child(1) i {
+    font-size: 0.8rem;
     font-style: normal;
     overflow-wrap: anywhere;
 }
-.msg-file > div:nth-child(2) a {
-    font-size: 0.8rem;
-}
-.msg-file > div:nth-child(2) p {
+.msg-file > div:nth-child(1) p {
     display: inline-block;
     font-size: 1rem;
-    margin-bottom: 0;
+    margin: 5px 0 0 0;
 }
-.msg-file > div:nth-child(3) {
+.msg-file > div:nth-child(2) {
     background: #0000002e;
     border-radius: 100%;
-    margin-left: 20px;
+    margin-left: 40px;
+    margin-right: 5px;
     cursor: pointer;
 }
-.msg-file > div:nth-child(3) svg {
+.msg-file > div:nth-child(2) svg {
     margin: 15px 10px 10px 10px;
     height: 20px;
-    width: 31px;
+    width: 27px;
 }
-.msg-file > div:nth-child(3) svg.download-bar {
+.msg-file > div:nth-child(2) svg.download-bar {
     --main-size: 40px;
     margin: 3px 1px -4px 0 !important;
 }
-.msg-file.me > div:nth-child(3) svg.download-bar > circle:last-child {
+.msg-file.me > div:nth-child(2) svg.download-bar > circle:last-child {
     stroke: var(--color-card-2);
 }
 

--- a/src/renderer/src/assets/css/msg.css
+++ b/src/renderer/src/assets/css/msg.css
@@ -344,8 +344,9 @@
     width: 27px;
 }
 .msg-file > div:nth-child(2) svg.download-bar {
-    --main-size: 40px;
+    --main-size: 24px;
     margin: 3px 1px -4px 0 !important;
+    padding: 10px;
 }
 .msg-file.me > div:nth-child(2) svg.download-bar > circle:last-child {
     stroke: var(--color-card-2);

--- a/src/renderer/src/assets/css/view.css
+++ b/src/renderer/src/assets/css/view.css
@@ -515,8 +515,8 @@ textarea:focus {
     transition:
         background 0.3s,
         color 0.3s;
-    background: var(--color-main);
-    color: var(--color-font-1-r);
+    background: var(--color-card-2);
+    color: var(--color-font);
     pointer-events: none;
     border-radius: 7px;
     padding: 15px;

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1020,4 +1020,29 @@ msgstr ""
 msgid "应用内通知和系统通知"
 msgstr ""
 
+msgid "成员设置"
+msgstr ""
 
+msgid "成员信息"
+msgstr ""
+
+msgid "成员昵称"
+msgstr ""
+
+msgid "啊吧啊吧……"
+msgstr ""
+
+msgid "操作"
+msgstr ""
+
+msgid "禁言成员"
+msgstr ""
+
+msgid "要让小猫咪不许说话几分钟呢？"
+msgstr ""
+
+msgid "成员头衔"
+msgstr ""
+
+msgid "猪咪猪咪"
+msgstr ""

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -998,3 +998,26 @@ msgstr "[{'@'}全体]"
 
 msgid "[特別关心]"
 msgstr ""
+
+msgid "离线文件"
+msgstr ""
+
+msgid "正在发送文件中……"
+msgstr ""
+
+msgid "群消息通知方式"
+msgstr ""
+
+msgid "重要消息将始终发起应用内通知和系统通知"
+msgstr ""
+
+msgid "不通知（默认）"
+msgstr ""
+
+msgid "仅应用内通知"
+msgstr ""
+
+msgid "应用内通知和系统通知"
+msgstr ""
+
+

--- a/src/renderer/src/assets/pathMap/NapCat.Onebot.yaml
+++ b/src/renderer/src/assets/pathMap/NapCat.Onebot.yaml
@@ -169,3 +169,34 @@ recent_contact:
 poke:
     name: group_poke
     private_name: friend_poke
+
+## 文件
+# 获取群文件主列表
+group_files:
+    name: get_group_root_files
+    source: $.data.*[*]
+    list:
+        # 文件类型
+        file_id: /file_id                   # 文件 ID
+        file_name: /file_name               # 文件名
+        size: /size                         # 文件大小
+        download_times: /download_times     # 下载次数
+        dead_time: /dead_time               # 过期时间
+        upload_time: /modify_time           # 上传时间
+        uploader_name: /uploader_name       # 上传者
+        # 文件夹类型
+        folder_id: /folder_id               # 文件夹 ID
+        folder_name: /folder_name           # 文件夹名
+        count: /total_file_count            # 文件数量
+        create_time: /create_time           # 创建时间
+        creater_name: /creator_name         # 创建者
+# 获取群文件夹内文件
+group_folder_files:
+    name: get_group_files_by_folder
+# 获取文件下载信息
+file_download:
+    name: get_group_file_url
+    private_name: get_private_file_url
+    source: $.data
+    list:
+        file_url: /url

--- a/src/renderer/src/assets/pathMap/NapCat.Onebot.yaml
+++ b/src/renderer/src/assets/pathMap/NapCat.Onebot.yaml
@@ -149,9 +149,6 @@ group_member_info:
         is_robot: /is_robot
         shut_up_timestamp: /shut_up_timestamp
         role: /role
-# 退出群聊
-leave_group:
-    name: set_group_leave
 # 获取收藏表情
 roaming_stamp:
     name: fetch_custom_face
@@ -200,3 +197,17 @@ file_download:
     source: $.data
     list:
         file_url: /url
+
+## 群操作
+# 退出群聊
+leave_group:
+    name: set_group_leave
+# 设置群昵称（包括成员）
+set_group_nickname:
+    name: set_group_card
+# 设置群头衔（包括成员）
+set_group_title:
+    name: set_group_special_title
+# 禁言成员
+ban_mumber:
+    name: set_group_ban

--- a/src/renderer/src/components/FileBody.vue
+++ b/src/renderer/src/components/FileBody.vue
@@ -40,41 +40,30 @@
                 <span v-else>{{ getSize(item.size) }}</span>
             </div>
         </div>
-        <div
-            v-if="item.file_id && item.download_percent === undefined"
-            class="download"
-            @click="getFile(item)">
-            <font-awesome-icon :icon="['fas', 'angle-down']" />
-        </div>
-        <svg
-            v-if="item.download_percent !== undefined"
-            class="download-bar"
-            xmlns="http://www.w3.org/2000/svg">
-            <circle
-                cx="50%"
-                cy="50%"
-                r="40%"
-                stroke-width="15%"
-                fill="none"
-                stroke-linecap="round" />
-            <circle
-                cx="50%"
-                cy="50%"
-                r="40%"
-                stroke-width="15%"
-                fill="none"
-                :stroke-dasharray="
-                    item.download_percent === undefined
-                        ? '0,10000'
-                        : `${(Math.floor(2 * Math.PI * 25) *
-                            item.download_percent) / 100},10000`
-                " />
-        </svg>
-        <div
-            v-show="item.show_items !== false && item.items !== undefined"
-            :class="
-                (item.items !== undefined ? 'sub_file ' : '') + 'group-files'
-            ">
+        <template v-if="item.file_id">
+            <div v-if="item.download_percent === undefined"
+                class="download"
+                @click="getFile(item)">
+                <font-awesome-icon :icon="['fas', 'angle-down']" />
+            </div>
+            <svg
+                v-else-if="item.download_percent !== undefined && item.download_percent < 100"
+                class="download-bar"
+                xmlns="http://www.w3.org/2000/svg">
+                <circle cx="50%" cy="50%" r="40%"
+                    stroke-width="15%" fill="none" stroke-linecap="round" />
+                <circle cx="50%" cy="50%" r="40%"
+                    stroke-width="15%" fill="none"
+                    :stroke-dasharray="
+                        item.download_percent === undefined ? '0,10000' :
+                        `${(Math.floor(2 * Math.PI * 25) * item.download_percent) / 100},10000` " />
+            </svg>
+            <div v-else class="download">
+                <font-awesome-icon :icon="['fas', 'check']" />
+            </div>
+        </template>
+        <div v-show="item.show_items !== false && item.items !== undefined"
+            :class="(item.items !== undefined ? 'sub_file ' : '') + 'group-files'">
             <div
                 v-for="sub_item in item.items"
                 :key="'sub_file-' + sub_item.file_id">

--- a/src/renderer/src/components/FileBody.vue
+++ b/src/renderer/src/components/FileBody.vue
@@ -128,7 +128,7 @@
                             group_id: runtimeData.chatInfo.show.id,
                             file_id: item.file_id,
                         },
-                        'downloadGroupFile_' + item.file_id + '_' + btoa(unescape(encodeURIComponent(item.file_name))),
+                        'downloadGroupFile_' + item.file_id + '_' + btoa(encodeURIComponent(item.file_name)),
                     )
                     // PS：在发起下载后就要将百分比设置好 …… 因为下载部分不一定立刻会开始
                     // 这时候如果用户疑惑为什么点了没反应会多次操作的（用户竟是我自己）

--- a/src/renderer/src/components/MsgBody.vue
+++ b/src/renderer/src/components/MsgBody.vue
@@ -151,38 +151,21 @@
                             </div>
                             <div>
                                 <font-awesome-icon
-                                    v-if="
-                                        item.downloadingPercentage === undefined
-                                    "
+                                    v-if="item.download_percent === undefined"
                                     :icon="['fas', 'angle-down']"
                                     @click="downloadFile(item, data.message_id)" />
                                 <svg
-                                    v-if="
-                                        item.downloadingPercentage !== undefined
-                                    "
+                                    v-else-if="item.download_percent !== undefined && item.download_percent < 100"
                                     class="download-bar"
                                     xmlns="http://www.w3.org/2000/svg">
-                                    <circle
-                                        cx="50%"
-                                        cy="50%"
-                                        r="40%"
-                                        stroke-width="15%"
-                                        fill="none"
-                                        stroke-linecap="round" />
-                                    <circle
-                                        cx="50%"
-                                        cy="50%"
-                                        r="40%"
-                                        stroke-width="15%"
-                                        fill="none"
-                                        :stroke-dasharray="
-                                            item.downloadingPercentage ===
-                                                undefined
-                                                ? '0,10000'
-                                                : `${(Math.floor(2 * Math.PI * 25) *
-                                                    item.downloadingPercentage) / 100},10000`
-                                        " />
+                                    <circle cx="50%" cy="50%" r="40%"
+                                        stroke-width="15%" ill="none" stroke-linecap="round" />
+                                    <circle cx="50%" cy="50%" r="40%"
+                                        stroke-width="15%" fill="none"
+                                        :stroke-dasharray="item.download_percent === undefined ? '0,10000' :
+                                            `${(Math.floor(2 * Math.PI * 25) * item.download_percent) / 100},10000`" />
                                 </svg>
+                                <font-awesome-icon v-else :icon="['fas', 'check']" />
                             </div>
                             <div
                                 v-if="data.fileView && Object.keys(data.fileView).length > 0"

--- a/src/renderer/src/components/MsgBody.vue
+++ b/src/renderer/src/components/MsgBody.vue
@@ -732,7 +732,7 @@
                     file_id: data.file_id,
                     group_id: runtimeData.chatInfo.show.type == 'group' ? runtimeData.chatInfo.show.id : undefined,
                 },
-                    'downloadFile_' + message_id + '_' + btoa(unescape(encodeURIComponent(data.name))),
+                    'downloadFile_' + message_id + '_' + btoa(encodeURIComponent(data.name)),
                 )
             },
 

--- a/src/renderer/src/function/elements/information.ts
+++ b/src/renderer/src/function/elements/information.ts
@@ -133,6 +133,29 @@ export interface UserGroupElem extends UserElem {
     class_name?: string
 }
 
+export interface GroupFileElem {
+    file_id: string
+    file_name: string
+    size: number
+    download_times: number
+    dead_time: number
+    upload_time: number
+    uploader_name: string
+
+    download_percent?: number
+}
+
+export interface GroupFileFolderElem {
+    folder_id: string
+    folder_name: string
+    count: number
+    create_time: number
+    creater_name: string
+
+    items?: GroupFileElem[]
+    show_items?: boolean
+}
+
 export interface GroupMemberInfoElem {
     user_id: number
     title: string

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -300,6 +300,34 @@ const noticeFunctions = {
 
 const msgFunctons = {
     /**
+     * 修改群成员信息回调
+     */
+    updateGroupMemberInfo: () => {
+        const $t = app.config.globalProperties.$t
+        const popInfo = {
+            title: $t('操作'),
+            html: `<span>${$t('正在确认操作……')}</span>`
+        }
+        runtimeData.popBoxList.push(popInfo)
+        // 稍微等一下再刷新成员列表
+        setTimeout(() => {
+            Connector.send(
+                'get_group_member_list',
+                { group_id: runtimeData.chatInfo.show.id, no_cache: true },
+                'getGroupMemberList',
+            )
+            setTimeout(() => {
+                Connector.send(
+                    'get_group_member_list',
+                    { group_id: runtimeData.chatInfo.show.id, no_cache: true },
+                    'getGroupMemberList',
+                )
+                runtimeData.popBoxList.shift()
+            }, 1000)
+        }, 1000)
+    },
+
+    /**
      * 保存 Bot 信息
      */
     getVersionInfo: (_: string, msg: { [key: string]: any }) => {
@@ -764,9 +792,8 @@ const msgFunctons = {
         if (msgItem && bodyIndex != -1) {
             const onProcess = function (event: ProgressEvent): undefined {
                 if (!event.lengthComputable) return
-                msgItem.message[bodyIndex].downloadingPercentage = Math.floor(
-                    (event.loaded / event.total) * 100,
-                )
+                const percent = Math.floor((event.loaded / event.total) * 100)
+                msgItem.message[bodyIndex].download_percent = percent
             }
             downloadFile(url, fileName, onProcess)
         }

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -29,6 +29,7 @@ import {
     orderOnMsgList,
 } from '@renderer/function/utils/msgUtil'
 import {
+    delay,
     getViewTime,
     randomNum,
 } from '@renderer/function/utils/systemUtil'
@@ -303,28 +304,28 @@ const msgFunctons = {
      * 修改群成员信息回调
      */
     updateGroupMemberInfo: () => {
-        const $t = app.config.globalProperties.$t
+        const { $t } = app.config.globalProperties
         const popInfo = {
             title: $t('操作'),
             html: `<span>${$t('正在确认操作……')}</span>`
         }
         runtimeData.popBoxList.push(popInfo)
         // 稍微等一下再刷新成员列表
-        setTimeout(() => {
+        delay(1000).then(() => {
             Connector.send(
                 'get_group_member_list',
                 { group_id: runtimeData.chatInfo.show.id, no_cache: true },
                 'getGroupMemberList',
             )
-            setTimeout(() => {
-                Connector.send(
-                    'get_group_member_list',
-                    { group_id: runtimeData.chatInfo.show.id, no_cache: true },
-                    'getGroupMemberList',
-                )
-                runtimeData.popBoxList.shift()
-            }, 1000)
-        }, 1000)
+            return delay(1000)
+        }).then(() => {
+            Connector.send(
+                'get_group_member_list',
+                { group_id: runtimeData.chatInfo.show.id, no_cache: true },
+                'getGroupMemberList',
+            )
+            runtimeData.popBoxList.shift()
+        })
     },
 
     /**
@@ -765,7 +766,7 @@ const msgFunctons = {
         const url = data.file_url
 
         const msgId = echoList[1]
-        const fileName = decodeURIComponent(escape(atob(echoList[2])))
+        const fileName = decodeURIComponent(atob(echoList[2]))
 
         // 寻找消息（逆序）
         const msgItem = runtimeData.messageList.find((item) => {
@@ -800,7 +801,7 @@ const msgFunctons = {
         const url = data.file_url
 
         const fileId = echoList[1]
-        const fileName = decodeURIComponent(escape(atob(echoList[2])))
+        const fileName = decodeURIComponent(atob(echoList[2]))
 
         const fileList = runtimeData.chatInfo.info.group_files as (GroupFileElem & GroupFileFolderElem)[]
 

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -331,11 +331,9 @@ const msgFunctons = {
      * 保存 Bot 信息
      */
     getVersionInfo: (_: string, msg: { [key: string]: any }) => {
-        const msgBody = getMsgData('version_info', msg, msgPath.version_info)
+        const data = getMsgData('version_info', msg, msgPath.version_info)[0]
 
-        if (msgBody) {
-            const data = msgBody[0]
-
+        if (data) {
             // 如果 runtime 存在（即不是第一次连接），且 app_name 不同，重置 runtime
             resetRimtime(
                 runtimeData.botInfo.app_name != data.app_name && !login.status,
@@ -381,20 +379,15 @@ const msgFunctons = {
                 action: 'label',
                 value: data.nickname,
             })
+            document.title = `${data.nickname}（${data.uin}）`
+            if(runtimeData.tags.platform == 'web') {
+                document.title = `${data.nickname}（${data.uin}）- Stapxs QQ Lite`
+            }
             // 结束登录页面的水波动画
             clearInterval(runtimeData.tags.loginWaveTimer)
             // 跳转标签卡
             const barMsg = document.getElementById('bar-msg')
             if (barMsg != null) barMsg.click()
-            // 获取更详细的信息
-            const url =
-                'https://find.qq.com/proxy/domain/cgi.find.qq.com/qqfind/find_v11?backver=2'
-            const info = `bnum=15&pagesize=15&id=0&sid=0&page=0&pageindex=0&ext=&guagua=1&gnum=12&guaguan=2&type=2&ver=4903&longitude=116.405285&latitude=39.904989&lbs_addr_country=%E4%B8%AD%E5%9B%BD&lbs_addr_province=%E5%8C%97%E4%BA%AC&lbs_addr_city=%E5%8C%97%E4%BA%AC%E5%B8%82&keyword=${data.uin}&nf=0&of=0&ldw=${data.bkn}`
-            Connector.send(
-                'http_proxy',
-                { url: url, method: 'post', data: info },
-                'getMoreLoginInfo',
-            )
             // 加载列表消息
             reloadUsers()
             reloadCookies()

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -15,7 +15,6 @@ import qed from '@renderer/assets/qed.txt?raw'
 
 import app from '@renderer/main'
 import Option from './option'
-import xss from 'xss'
 import pinyin from 'tiny-pinyin'
 
 import Umami from '@stapxs/umami-logger-typescript'
@@ -31,7 +30,6 @@ import {
 } from '@renderer/function/utils/msgUtil'
 import {
     getViewTime,
-    escape2Html,
     randomNum,
 } from '@renderer/function/utils/systemUtil'
 import {
@@ -46,6 +44,8 @@ import { reactive, markRaw, defineAsyncComponent } from 'vue'
 import { PopInfo, PopType, Logger, LogType } from './base'
 import { Connector, login } from './connect'
 import {
+    GroupFileElem,
+    GroupFileFolderElem,
     GroupMemberInfoElem,
     UserFriendElem,
     UserGroupElem,
@@ -610,6 +610,14 @@ const msgFunctons = {
             )
         }
     },
+    sendFileBack: (
+        _: string,
+        msg: { [key: string]: any },
+        echoList: string[],
+    ) => {
+        runtimeData.popBoxList.shift()
+        msgFunctons['sendMsgBack'](_, msg, echoList)
+    },
 
     /**
      * 获取收藏表情
@@ -671,183 +679,140 @@ const msgFunctons = {
 
     /**
      * 获取群文件列表
-     * @deprecated 功能在后期更新中未被重构检查，可能存在问题
      */
     getGroupFiles: (_: string, msg: { [key: string]: any }) => {
-        const data = msg.data.data
-        const div = document.createElement('div')
-        div.innerHTML = data.em
-        if (data.ec !== 0) {
-            popInfo.add(
-                PopType.ERR,
-                app.config.globalProperties.$t('加载群文件失败（{code}）', {
-                    code: xss(div.innerHTML),
-                }),
-            )
-        } else {
-            runtimeData.chatInfo.info.group_files = data
-        }
+        const list = getMsgData('group_files', msg, msgPath.group_files) as (GroupFileElem & GroupFileFolderElem)[]
+        // 排序；文件夹在前，文件在后
+        const folderList = list.filter((item) => {
+            return item.folder_id
+        })
+        const fileList = list.filter((item) => {
+            return item.file_id
+        })
+        // 对它们各自排序，文件夹按照 create_time 降序，文件按照 upload_time 降序
+        folderList.sort((a, b) => {
+            return b.create_time - a.create_time
+        })
+        fileList.sort((a, b) => {
+            return b.upload_time - a.upload_time
+        })
+        // 合并
+        runtimeData.chatInfo.info.group_files = folderList.concat(fileList)
     },
 
     /**
-     * 获取群文件列表（分页）
-     * @deprecated 功能在后期更新中未被重构检查，可能存在问题
+     * 获取群文件文件夹文件
      */
-    getMoreGroupFiles: (_: string, msg: { [key: string]: any }) => {
-        const data = msg.data.data
-        if (
-            runtimeData.chatInfo.info !== undefined &&
-            runtimeData.chatInfo.info.group_files !== undefined
-        ) {
-            // 追加文件列表
-            runtimeData.chatInfo.info.group_files.file_list =
-                runtimeData.chatInfo.info.group_files.file_list.concat(
-                    data.file_list,
-                )
-            // 设置最大值位置
-            runtimeData.chatInfo.info.group_files.next_index = data.next_index
+    getGroupDirFiles: (_: string, msg: { [key: string]: any }, echoList: string[]) => {
+        // TODO: 有分页
+
+        // 默认使用主目录相同的结构，如果存在子目录结构的定义则使用子目录的结构
+        let map = msgPath.group_files
+        if(msgPath.group_folder_files.source) {
+            map = msgPath.group_folder
+        }
+        const list = getMsgData('group_files', msg, map) as (GroupFileElem & GroupFileFolderElem)[]
+        // 排序；文件夹在前，文件在后
+        const folderList = list.filter((item) => {
+            return item.folder_id
+        })
+        const fileList = list.filter((item) => {
+            return item.file_id
+        })
+        // 对它们各自排序，文件夹按照 create_time 降序，文件按照 upload_time 降序
+        folderList.sort((a, b) => {
+            return b.create_time - a.create_time
+        })
+        fileList.sort((a, b) => {
+            return b.upload_time - a.upload_time
+        })
+        // 寻找 item
+        const folderId = echoList[1]
+        const folder = runtimeData.chatInfo.info.group_files.find((item) => {
+            return item.folder_id == folderId
+        })
+        if (folder) {
+            folder.items = fileList
         }
     },
 
     /**
      * 下载文件（聊天中）
-     * @deprecated 功能在后期更新中未被重构检查，可能存在问题
      */
-    downloadFile: (_: string, msg: { [key: string]: any }) => {
-        const info = msg.echo.split('_')
-        const msgId = info[1]
-        const url = msg.data.url
-        // 在消息列表内寻找这条消息（从后往前找）
-        let index = -1
-        let indexMsg = -1
-        for (let i = runtimeData.messageList.length - 1; i > 0; i--) {
-            if (runtimeData.messageList[i].message_id == msgId) {
-                index = i
-                for (
-                    let j = 0;
-                    j < runtimeData.messageList[i].message.length;
-                    j++
-                ) {
-                    if (runtimeData.messageList[i].message[j].type == 'file') {
-                        indexMsg = j
-                        break
-                    }
+    downloadFile: (_: string, msg: { [key: string]: any }, echoList: string[]) => {
+        const data = getMsgData('file_download', msg, msgPath.file_download)[0]
+        const url = data.file_url
+
+        const msgId = echoList[1]
+        const fileName = decodeURIComponent(escape(atob(echoList[2])))
+
+        // 寻找消息（逆序）
+        const msgItem = runtimeData.messageList.find((item) => {
+            return item.message_id == msgId
+        })
+        // 寻找 file 类型消息（一般是第一个）
+        let bodyIndex = -1
+        if (msgItem) {
+            msgItem.message.forEach((item, index) => {
+                if (item.type == 'file') {
+                    bodyIndex = index
                 }
-                break
-            }
+            })
         }
+
         // 下载文件
-        if (index != -1 && indexMsg != -1) {
+        if (msgItem && bodyIndex != -1) {
             const onProcess = function (event: ProgressEvent): undefined {
                 if (!event.lengthComputable) return
-                runtimeData.messageList[index].message[
-                    indexMsg
-                ].downloadingPercentage = Math.floor(
+                msgItem.message[bodyIndex].downloadingPercentage = Math.floor(
                     (event.loaded / event.total) * 100,
                 )
             }
-            downloadFile(
-                url,
-                msg.echo.substring(
-                    msg.echo.lastIndexOf('_') + 1,
-                    msg.echo.length,
-                ),
-                onProcess,
-            )
+            downloadFile(url, fileName, onProcess)
         }
     },
 
     /**
      * 下载文件（群文件）
-     * @deprecated 功能在后期更新中未被重构检查，可能存在问题
      */
-    downloadGroupFile: (_: string, msg: { [key: string]: any }) => {
-        // 基本信息
-        const info = msg.echo.split('_')
-        const id = info[1]
-        // 文件信息
-        let fileName = 'new-file'
-        let fileIndex = -1
-        let subFileIndex = -1
-        runtimeData.chatInfo.info.group_files.file_list.forEach(
-            (item: any, index: number) => {
-                if (item.id === id) {
-                    fileName = escape2Html(item.name)
-                    fileIndex = index
-                }
-            },
-        )
-        // 特殊情况：这是个子文件
-        if (info[2] !== undefined) {
-            runtimeData.chatInfo.info.group_files.file_list[
-                fileIndex
-            ].sub_list.forEach((item: any, index: number) => {
-                if (item.id === info[2]) {
-                    fileName = escape2Html(item.name)
-                    subFileIndex = index
-                }
-            })
-        }
+    downloadGroupFile: (_: string, msg: { [key: string]: any }, echoList: string[]) => {
+        const data = getMsgData('file_download', msg, msgPath.file_download)[0]
+        const url = data.file_url
+
+        const fileId = echoList[1]
+        const fileName = decodeURIComponent(escape(atob(echoList[2])))
+
+        const fileList = runtimeData.chatInfo.info.group_files as (GroupFileElem & GroupFileFolderElem)[]
+
+        let listItem = undefined as GroupFileElem | undefined
+        // 寻找文件列表位置
+        fileList.forEach((item, index) => {
+            if (item.file_id == fileId) {
+                listItem = fileList[index]
+            }
+            if (item.items) {
+                item.items.forEach((subItem, subIndex) => {
+                    if (subItem.file_id == fileId && fileList[index]?.items) {
+                        listItem = fileList[index].items[subIndex]
+                    }
+                })
+            }
+        })
+
         // 下载事件
         const onProcess = function (event: ProgressEvent): undefined {
             if (!event.lengthComputable) return
-            const downloadingPercentage = Math.floor(
-                (event.loaded / event.total) * 100,
-            )
-            if (fileIndex !== -1) {
-                if (subFileIndex === -1) {
-                    if (
-                        runtimeData.chatInfo.info.group_files.file_list[
-                            fileIndex
-                        ].downloadingPercentage === undefined
-                    ) {
-                        runtimeData.chatInfo.info.group_files.file_list[
-                            fileIndex
-                        ].downloadingPercentage = 0
-                    }
-                    runtimeData.chatInfo.info.group_files.file_list[
-                        fileIndex
-                    ].downloadingPercentage = downloadingPercentage
-                } else {
-                    if (
-                        runtimeData.chatInfo.info.group_files.file_list[
-                            fileIndex
-                        ].sub_list[subFileIndex].downloadingPercentage ===
-                        undefined
-                    ) {
-                        runtimeData.chatInfo.info.group_files.file_list[
-                            fileIndex
-                        ].sub_list[subFileIndex].downloadingPercentage = 0
-                    }
-                    runtimeData.chatInfo.info.group_files.file_list[
-                        fileIndex
-                    ].sub_list[subFileIndex].downloadingPercentage =
-                        downloadingPercentage
+            const percent = Math.floor((event.loaded / event.total) * 100)
+            if(listItem) {
+                if(listItem.download_percent == undefined) {
+                    listItem.download_percent = 0
                 }
+                listItem.download_percent = percent
             }
         }
 
         // 下载文件
-        downloadFile(msg.data.url, fileName, onProcess)
-    },
-
-    /**
-     * 获取群文件文件夹文件
-     * @deprecated 功能在后期更新中未被重构检查，可能存在问题
-     */
-    getGroupDirFiles: (_: string, msg: { [key: string]: any }) => {
-        // TODO: 这边不分页直接拿全，还没写
-        const id = msg.echo.split('_')[1]
-        let fileIndex = -1
-        runtimeData.chatInfo.info.group_files.file_list.forEach(
-            (item: any, index: number) => {
-                if (item.id === id) {
-                    fileIndex = index
-                }
-            },
-        )
-        runtimeData.chatInfo.info.group_files.file_list[fileIndex].sub_list =
-            msg.data.data.file_list
+        downloadFile(url, fileName, onProcess)
     },
 
     /**
@@ -858,18 +823,16 @@ const msgFunctons = {
         msg: { [key: string]: any },
         echoList: string[],
     ) => {
-        let url = msg.data.url
+        const data = getMsgData('file_download', msg, msgPath.file_download)[0]
+        let url = data.file_url
         const msgId = echoList[1]
         const ext = echoList[2]
         if (url) {
-            // 寻找消息位置
-            let msgIndex = -1
-            runtimeData.messageList.forEach((item, index) => {
-                if (item.message_id === msgId) {
-                    msgIndex = index
-                }
+            // 寻找消息
+            const msg = runtimeData.messageList.find((item) => {
+                return item.message_id == msgId
             })
-            if (msgIndex !== -1) {
+            if (msg) {
                 if (document.location.protocol == 'https:') {
                     // 判断文件 URL 的协议
                     // PS：Chrome 不会对 http 文件进行协议升级
@@ -877,8 +840,8 @@ const msgFunctons = {
                         url = 'https' + url.substring(url.indexOf('://'))
                     }
                 }
-                runtimeData.messageList[msgIndex].fileView.url = url
-                runtimeData.messageList[msgIndex].fileView.ext = ext
+                msg.fileView.url = url
+                msg.fileView.ext = ext
             }
         }
     },

--- a/src/renderer/src/function/utils/appUtil.ts
+++ b/src/renderer/src/function/utils/appUtil.ts
@@ -241,7 +241,7 @@ export function downloadFile(
             url = 'https' + url.substring(url.indexOf('://'))
         }
     }
-    if (runtimeData.tags.isElectron) {
+    if (!runtimeData.tags.isElectron) {
         try {
             new FileDownloader({
                 url: url,
@@ -744,7 +744,7 @@ function showUpadteLog(data: any) {
     // 这儿有两种情况：
     //    如果当前版本小于获取到的版本就是有更新
     //    如果缓存版本小于获取到的版本但是当前版本等于获取到的版本就是更新完成首次启动
-    constlatestVersion = data.tag_name.substring(1)
+    const latestVersion = data.tag_name.substring(1)
 
     if (semver.lt(appVersion,latestVersion)) {
         // 有更新

--- a/src/renderer/src/function/utils/msgUtil.ts
+++ b/src/renderer/src/function/utils/msgUtil.ts
@@ -410,6 +410,7 @@ export function sendMsgRaw(
     type: string,
     msg: string | any[] | undefined,
     preShow = false,
+    echo = 'sendMsgBack',
 ) {
     // 如果消息为空则不发送
     if(msg == undefined || msg == '' || (Array.isArray(msg) && msg.length == 0)) {
@@ -474,7 +475,7 @@ export function sendMsgRaw(
                     runtimeData.jsonMap.message_list.name_group_send ??
                         'send_msg',
                     { group_id: id, message: msg },
-                    'sendMsgBack_uuid_' + msgUUID,
+                    echo + '_uuid_' + msgUUID,
                 )
                 break
             case 'user': {
@@ -487,14 +488,14 @@ export function sendMsgRaw(
                             group_id: id.split('/')[1],
                             message: msg,
                         },
-                        'sendMsgBack_uuid_' + msgUUID,
+                        echo + '_uuid_' + msgUUID,
                     )
                 } else {
                     Connector.send(
                         runtimeData.jsonMap.message_list.name_user_send ??
                             'send_msg',
                         { user_id: id, message: msg },
-                        'sendMsgBack_uuid_' + msgUUID,
+                        echo + '_uuid_' + msgUUID,
                     )
                 }
                 break

--- a/src/renderer/src/function/utils/systemUtil.ts
+++ b/src/renderer/src/function/utils/systemUtil.ts
@@ -4,6 +4,15 @@ import l10nConfig from '@renderer/assets/l10n/_l10nconfig.json'
 import PO from 'pofile'
 
 /**
+ * 异步延迟
+ * @param ms 延迟时间
+ * @returns Promise<void>
+ */
+export function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
  * 区分安卓、iOS、MacOS 和其他
  */
 export function getDeviceType() {

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -728,11 +728,22 @@
                     </div>
                     <a>{{ $t('移出群聊') }}</a>
                 </div>
+                <div
+                    v-show="tags.menuDisplay.config"
+                    @click="openChatInfoPan();
+                            $refs.infoRef?.openMoreConfig(selectedMsg?.sender.user_id);
+                            closeMsgMenu();">
+                    <div>
+                        <font-awesome-icon :icon="['fas', 'cog']" />
+                    </div>
+                    <a>{{ $t('成员设置') }}</a>
+                </div>
             </div>
         </div>
         <!-- 群 / 好友信息弹窗 -->
         <Transition>
             <Info
+                ref="infoRef"
                 :chat="chat"
                 :tags="tags"
                 @close="openChatInfoPan" />
@@ -942,6 +953,7 @@
                         remove: false,
                         respond: false,
                         showRespond: true,
+                        config: false,
                     },
                     search: {
                         userId: -1,
@@ -1377,6 +1389,11 @@
                             // 自己不显示提及
                             this.tags.menuDisplay.at = false
                         }
+                        // 群成员设置
+                        if(runtimeData.chatInfo.show.type == 'group' &&
+                        runtimeData.chatInfo.info.me_info.role != 'member') {
+                            this.tags.menuDisplay.config = true
+                        }
                     } else {
                         // 检查消息，确认菜单显示状态
                         if (
@@ -1511,6 +1528,7 @@
                     remove: false,
                     respond: false,
                     showRespond: true,
+                    config: false,
                 }
             },
 

--- a/src/renderer/src/pages/Info.vue
+++ b/src/renderer/src/pages/Info.vue
@@ -123,7 +123,10 @@
                         <div v-for="item in number_cache.length > 0 ? number_cache : chat.info.group_members"
                             :key="'chatinfomlist-' + item.user_id"
                             :class="canEditMember(item.role) ? 'edit' : ''">
-                            <img loading="lazy" :src="`https://q1.qlogo.cn/g?b=qq&s=0&nk=${item.user_id}`">
+                            <img
+                                alt="nk"
+                                loading="lazy"
+                                :src="`https://q1.qlogo.cn/g?b=qq&s=0&nk=${item.user_id}`">
                             <div>
                                 <a @click="startChat(item)">{{
                                     item.card ? item.card : item.nickname
@@ -170,7 +173,9 @@
             </BcTab>
             <div :class="'ss-card user-config' + (Object.keys(showUserConfig).length > 0 ? ' show' : '')">
                 <div>
-                    <img :src="`https://q1.qlogo.cn/g?b=qq&s=0&nk=${showUserConfig.user_id}`">
+                    <img
+                        alt="nk"
+                        :src="`https://q1.qlogo.cn/g?b=qq&s=0&nk=${showUserConfig.user_id}`">
                     <div>
                         <a>{{ showUserConfig.card != '' ? showUserConfig.card : showUserConfig.nickname }}</a>
                         <span>{{ showUserConfig.user_id }}</span>
@@ -400,10 +405,8 @@ import { Connector } from '@renderer/function/connect'
                     const num = parseInt(value)
                     if (isNaN(num)) {
                         (event.target as HTMLInputElement).value = ''
-                    } else {
-                        if (num < 0) {
-                            (event.target as HTMLInputElement).value = '0'
-                        }
+                    } else if (num < 0) {
+                        (event.target as HTMLInputElement).value = '0'
                     }
                 }
             },

--- a/src/renderer/src/pages/Info.vue
+++ b/src/renderer/src/pages/Info.vue
@@ -156,24 +156,13 @@
                 </div>
                 <div :name="$t('文件')">
                     <div
-                        class="group-files"
-                        @scroll="fileLoad">
+                        class="group-files">
                         <div
-                            v-for="item in chat.info.group_files.file_list"
-                            :key="'file-' + item.id">
+                            v-for="item in chat.info.group_files as (GroupFileElem & GroupFileFolderElem)[]"
+                            :key="'file-' + (item.folder_id ?? item.file_id)">
                             <FileBody
                                 :chat="chat"
                                 :item="item" />
-                        </div>
-                        <div
-                            v-show="
-                                chat.info.group_files !== undefined &&
-                                    chat.info.group_files.next_index !==
-                                    undefined &&
-                                    chat.info.group_files.next_index !== 0
-                            "
-                            class="group-files-loader">
-                            <font-awesome-icon :icon="['fas', 'ellipsis']" />
                         </div>
                     </div>
                 </div>
@@ -201,6 +190,8 @@
     import { getTrueLang } from '@renderer/function/utils/systemUtil'
     import { runtimeData } from '@renderer/function/msg'
     import {
+        GroupFileElem,
+        GroupFileFolderElem,
         UserFriendElem,
         UserGroupElem,
     } from '@renderer/function/elements/information'
@@ -209,7 +200,7 @@
         name: 'ViewInfo',
         components: { BulletinBody, FileBody, OptInfo, BcTab },
         props: ['tags', 'chat'],
-        emits: ['close', 'loadFile'],
+        emits: ['close'],
         data() {
             return {
                 runtimeData: runtimeData,
@@ -224,14 +215,6 @@
              */
             closeChatInfoPan() {
                 this.$emit('close', null)
-            },
-
-            /**
-             * 加载更多文件
-             * @param event 滚动事件
-             */
-            fileLoad(event: Event) {
-                this.$emit('loadFile', event)
             },
 
             /**

--- a/src/renderer/src/pages/Info.vue
+++ b/src/renderer/src/pages/Info.vue
@@ -163,7 +163,8 @@
                     <div style="padding: 0 20px">
                         <OptInfo
                             :type="'group'"
-                            :chat="chat" />
+                            :chat="chat"
+                            @update_mumber_card="updateMumberCard" />
                     </div>
                 </div>
             </BcTab>
@@ -210,23 +211,25 @@
                             type="text"
                             @change="updateMumberTitle($event, showUserConfig)">
                     </div>
-                    <header>{{ $t('操作') }}</header>
-                    <div class="opt-item">
-                        <font-awesome-icon :icon="['fas', 'clipboard-list']" />
-                        <div>
-                            <span>{{ $t('禁言成员') }}</span>
-                            <span>{{
-                                $t('要让小猫咪不许说话几分钟呢？')
-                            }}</span>
+                    <template v-if="showUserConfig.role === 'member'">
+                        <header>{{ $t('操作') }}</header>
+                        <div class="opt-item">
+                            <font-awesome-icon :icon="['fas', 'clipboard-list']" />
+                            <div>
+                                <span>{{ $t('禁言成员') }}</span>
+                                <span>{{
+                                    $t('要让小猫咪不许说话几分钟呢？')
+                                }}</span>
+                            </div>
+                            <input
+                                v-model="mumberInfo.banMin"
+                                style="width: 50%"
+                                class="ss-input"
+                                type="text"
+                                @input="checkNumber"
+                                @change="banMumber($event, showUserConfig)">
                         </div>
-                        <input
-                            v-model="mumberInfo.banMin"
-                            style="width: 50%"
-                            class="ss-input"
-                            type="text"
-                            @input="checkNumber"
-                            @change="banMumber($event, showUserConfig)">
-                    </div>
+                    </template>
                 </div>
             </div>
         </div>
@@ -276,7 +279,7 @@ import { Connector } from '@renderer/function/connect'
                     if (num > 0) {
                         const popInfo = {
                             title: this.$t('操作'),
-                            html: `<span>${this.$t('确认禁言成员？')}</span>`,
+                            html: `<span>${this.$t('确认禁言？')}</span>`,
                             button: [
                                 {
                                     text: this.$t('确认'),
@@ -312,7 +315,7 @@ import { Connector } from '@renderer/function/connect'
                 if (this.showUserConfig.card !== value) {
                     const popInfo = {
                         title: this.$t('操作'),
-                        html: `<span>${this.$t('确认修改成员昵称？')}</span>`,
+                        html: `<span>${this.$t('确认修改昵称？')}</span>`,
                         button: [
                             {
                                 text: this.$t('确认'),
@@ -347,7 +350,7 @@ import { Connector } from '@renderer/function/connect'
                 if (this.showUserConfig.card !== value) {
                     const popInfo = {
                         title: this.$t('操作'),
-                        html: `<span>${this.$t('确认修改成员头衔？')}</span>`,
+                        html: `<span>${this.$t('确认修改头衔？')}</span>`,
                         button: [
                             {
                                 text: this.$t('确认'),

--- a/src/renderer/src/pages/options/OptAccount.vue
+++ b/src/renderer/src/pages/options/OptAccount.vue
@@ -117,7 +117,7 @@
                                 key !== 'app_version' &&
                                 key !== 'version'
                         ">
-                        <span>{{ $t('botinfo_' + key) + ': ' }}</span>
+                        <span>{{ key + ': ' }}</span>
                         <span
                             v-if="typeof runtimeData.botInfo[key] !== 'object'">
                             {{ paseBotInfo(key, runtimeData.botInfo[key]) }}
@@ -133,18 +133,7 @@
                             "
                             :key="'botinfo-' + key + item">
                             {{
-                                (typeof runtimeData.botInfo[key][item] ==
-                                    'number'
-                                    ? $t(
-                                        'botinfo_' + item,
-                                        runtimeData.botInfo[key][item],
-                                    )
-                                    : $t('botinfo_' + item)) +
-                                    ': ' +
-                                    paseBotInfo(
-                                        item,
-                                        runtimeData.botInfo[key][item],
-                                    )
+                                item + ': ' + paseBotInfo(item, runtimeData.botInfo[key][item])
                             }}
                         </span>
                     </span>

--- a/src/renderer/src/pages/options/OptInfo.vue
+++ b/src/renderer/src/pages/options/OptInfo.vue
@@ -46,7 +46,7 @@
                     class="ss-input"
                     style="width: 150px"
                     type="text"
-                    @keyup="setGroupCard">
+                    @change="setGroupCard">
             </div>
 
             <button
@@ -68,6 +68,7 @@
     export default defineComponent({
         name: 'ViewOptInfo',
         props: ['type', 'chat'],
+        emits: ['update_mumber_card'],
         data() {
             return {
                 runtimeData: runtimeData,
@@ -78,18 +79,8 @@
              * 设置群名片
              * @param event 按键事件
              */
-            setGroupCard(event: KeyboardEvent) {
-                if (event.key === 'Enter') {
-                    Connector.send(
-                        'set_group_card',
-                        {
-                            group_id: this.chat.show.id,
-                            user_id: runtimeData.loginInfo.uin,
-                            card: runtimeData.chatInfo.info.me_info.card,
-                        },
-                        'setGroupCard',
-                    )
-                }
+            setGroupCard(event: Event) {
+                this.$emit('update_mumber_card', event, runtimeData.chatInfo.info.me_info)
             },
 
             /**

--- a/src/renderer/src/pages/options/OptInfo.vue
+++ b/src/renderer/src/pages/options/OptInfo.vue
@@ -146,7 +146,7 @@
                     ],
                 }
                 runtimeData.popBoxList.push(popInfo)
-            },
+            }
         },
     })
 </script>


### PR DESCRIPTION
### 文件功能修正
此版本合并主要提供文件相关功能的修正，以及一些零散的 issue 功能请求新增

:sparkles: 增加群成员设置页面，提供修改群昵称、头衔、禁言成员相关功能 <- #190 #194
:bug: 修复 electron 在 debug 下遇到 websocket 未关闭的情况
:bug: 对年久失修的文件功能进行了修复；包括上传下载、快捷预览、群文件列表；目前仅适配 Napcat，其他端请请求 issue <- #192 #193
:lipstick: 优化文件下载过程的提示样式
:lipstick: 提供一种新的无法关闭的 popBox 样式用于提示耗时操作，防止用户继续操作
:art: 对群成员设置面板样式进行一些优化
:egg: 增加一些标题彩蛋
:green_heart: 调整构建，提供 pacman 构建，同时为了优化构建时间；从此版本开始将不提供除了 macOS 版以外的所有 arm 构建 <- #197

## Sourcery 嘅摘要

呢個pull request提供咗文件相關函數嘅修復，並添加咗一個群組成員設定頁面。佢仲包括UI增強、構建調整同埋一啲細功能。

新功能：
- 添加咗一個群組成員設定頁面，提供修改群組暱稱、頭銜同埋禁言成員嘅功能。

Bug修復：
- 修復咗Electron喺debug模式下遇到未關閉WebSocket嘅問題。
- 修復咗文件相關函數，包括上傳/下載、快速預覽同埋群組文件列表，目前已適配Napcat。

增強：
- 改善咗文件下載期間嘅提示風格。
- 提供咗一個新嘅唔可以關閉嘅popBox風格，用於提示耗時操作，防止用戶繼續操作。
- 優化咗群組成員設定面板嘅風格。

構建：
- 調整咗構建，以提供Pacman構建，並且為咗優化構建時間，呢個版本將唔再提供除咗macOS版本之外嘅任何ARM構建。

雜項：
- 添加咗一啲標題彩蛋。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request provides fixes for file-related functions and adds a group member settings page. It also includes UI enhancements, build adjustments, and minor features.

New Features:
- Adds a group member settings page, providing functions for modifying group nicknames, titles, and muting members.

Bug Fixes:
- Fixes an issue where Electron encounters an unclosed WebSocket in debug mode.
- Repairs file-related functions, including upload/download, quick preview, and group file list, currently adapted for Napcat.

Enhancements:
- Improves the prompt style during file downloads.
- Provides a new unclosable popBox style for prompting time-consuming operations, preventing users from continuing operations.
- Optimizes the style of the group member settings panel.

Build:
- Adjusts the build to provide Pacman builds, and to optimize build time, this version will no longer provide any ARM builds other than the macOS version.

Chores:
- Adds some title easter eggs.

</details>