### PR TITLE
在非JSON的转发的聊天记录中展示前三条消息

### DIFF
--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1079,3 +1079,24 @@ msgstr ""
 
 msgid "跳转到消息"
 msgstr ""
+
+msgid "合并转发消息"
+msgstr ""
+
+msgid "[图片]"
+msgstr ""
+
+msgid "[表情]"
+msgstr ""
+
+msgid "[文件]"
+msgstr ""
+
+msgid "[视频]"
+msgstr ""
+
+msgid "[聊天记录]"
+msgstr ""
+
+msgid "[不支持的消息]"
+msgstr ""

--- a/src/renderer/src/components/MsgBody.vue
+++ b/src/renderer/src/components/MsgBody.vue
@@ -154,7 +154,37 @@
                             class="msg-unknown"
                             style="cursor: pointer"
                             @click="View.getForwardMsg(item.id)">
-                            {{ $t('（点击查看合并转发消息）') }}
+                            {{ $t('合并转发消息') }}
+                            <div v-for="(i, index) in item.content.slice(0, 3)">
+                                {{i.sender.nickname}}:
+                                <span v-for="(msg, msgIndex) in i.message">
+                                    <span v-if="msg.type == 'text'">
+                                        {{ msg.data.text }}
+                                    </span>
+                                    <span v-else-if="msg.type == 'image'">
+                                        {{ $t('[图片]') }}
+                                    </span>
+                                    <span v-else-if="msg.type == 'face' || msg.type == 'bface'">
+                                        {{ $t('[表情]') }}
+                                    </span>
+                                    <span v-else-if="msg.type == 'file'">
+                                        {{ $t('[文件]') }}{{ msg.data.file }}
+                                    </span>
+                                    <span v-else-if="msg.type == 'video'">
+                                        {{ $t('[视频]') }}
+                                    </span>
+                                    <span v-else-if="msg.type == 'forward'">
+                                        {{ $t('[聊天记录]') }}
+                                    </span>
+                                    <span v-else-if="msg.type == 'reply'">
+                                        <!--原版QQ此处不做处理-->
+                                    </span>
+                                    <span v-else>
+                                        {{ $t('[不支持的消息]') }}
+                                    </span>
+                                </span>
+                            </div>
+                            {{ $t('（点击查看合并转发消息）')  }}
                         </span>
                         <div v-else-if="item.type == 'reply'"
                             :class="isMe ? type == 'merge' ? 'msg-replay' : 'msg-replay me' : 'msg-replay'"


### PR DESCRIPTION
在非JSON的转发的聊天记录中将会展示前三条消息

示例：

![image](https://github.com/user-attachments/assets/5e295882-8831-4a81-9ccc-d1f9b9452e1c)

## Sourcery 嘅摘要

增強轉發嘅聊天訊息嘅顯示，喺預覽度顯示頭三個訊息

新功能：
- 加咗轉發嘅聊天記錄嘅頭三個訊息嘅預覽，顯示發送者嘅暱稱同埋訊息內容，並處理唔同嘅訊息類型

增強功能：
- 通過喺完整視圖之前提供轉發訊息內容嘅快速預覽，改善用戶體驗

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the display of forwarded chat messages by showing the first three messages in the preview

New Features:
- Add preview of first three messages in forwarded chat records, displaying sender nickname and message content with different message type handling

Enhancements:
- Improve user experience by providing a quick preview of forwarded message content before full view

</details>