### PR TITLE
修复了用最新的分支编译后转发消息消息条数显示的问题

### DIFF
--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1078,6 +1078,7 @@ msgid "合并转发消息"
 msgstr ""
 
 msgid "查看 {count} 条转发消息"
+msgstr "查看 {count} 条转发消息"
 
 msgid "浏览"
 msgstr ""


### PR DESCRIPTION
![屏幕截图_20250410_172302](https://github.com/user-attachments/assets/bb8075a9-99c2-480b-8eea-bd4c94be5ab5)

->

![屏幕截图_20250410_172231](https://github.com/user-attachments/assets/51803c01-81f9-4e54-a0cd-f585b71409d3)

用占位符的话，不填i18n字符串显示会有问题……

## Sourcery 嘅總結

修正最新分支入面嘅訊息數量顯示嘅本地化問題

Bug 修正:
- 解決咗喺國際化 (i18n) 字串入面用緊佔位符嗰陣，訊息數量顯示有問題嘅情況

文件:
- 更新咗簡體中文本地化檔案，修正訊息數量顯示

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix localization issue with message count display in the latest branch

Bug Fixes:
- Resolved an issue where message count display was problematic when using placeholders in internationalization (i18n) strings

Documentation:
- Updated Chinese (Simplified) localization file to correct message count display

</details>