### PR TITLE
修复带有时间戳的时候消息跳动问题

### DIFF
--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -78,7 +78,7 @@
                     <!-- 时间戳 -->
                     <NoticeBody
                         v-if="isShowTime(list[index - 1] ? list[index - 1].time : undefined, msgIndex.time)"
-                        :key="'notice-time-' + index"
+                        :key="'notice-time-' + msgIndex.time"
                         :data="{ sub_type: 'time', time: msgIndex.time }" />
                     <!-- 消息体 -->
                     <MsgBody v-if="(msgIndex.post_type === 'message' ||

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -78,7 +78,7 @@
                     <!-- 时间戳 -->
                     <NoticeBody
                         v-if="isShowTime(list[index - 1] ? list[index - 1].time : undefined, msgIndex.time)"
-                        :key="'notice-time-' + msgIndex.time"
+                        :key="'notice-time-' + (msgIndex.time / ( 4 * 60 )).toFixed(0)"
                         :data="{ sub_type: 'time', time: msgIndex.time }" />
                     <!-- 消息体 -->
                     <MsgBody v-if="(msgIndex.post_type === 'message' ||


### PR DESCRIPTION
还是 #223 提到的问题 

#224 仅修复了没有时间戳时的跳跃问题

而时间戳的key是`'notice-time-' + index`，由于发送消息会令数组shift一下，导致index变化，进而导致key变化，导致组件刷新，导致消息跳跃

但无论怎样的变化 时间戳是不会变得 因此将其改为`'notice-time-' + (msgIndex.time / ( 4 * 60 )).toFixed(0)`

>改成`'notice-time-' + (msgIndex.time / ( 4 * 60 )).toFixed(0)`而不是 `'notice-time-' + msgIndex.time` 的原因是
>
>当间隔时间太长（超过5分钟）再发送消息 就会出现因为发送时间（按下回车发送，例如20:00:00）和实际发出时间（由于网络延迟，20:00:02才发送成功）不一致导致key变化，进而导致跳跃
>
> (msgIndex.time / ( 4 * 60 )).toFixed(0) 则尽可能保证发送时间和实际发出时间生成的key一致，避免跳动
>


改后效果：

![1](https://github.com/user-attachments/assets/1c7914bb-31e3-4952-bba0-d1db0ec629c9)

(注：时间戳是我强行让他显示的)

## Sourcery 嘅摘要

修正訊息時間戳記嘅呈現方式，以防止唔必要嘅組件刷新同訊息跳動

Bug 修复：
- 解決咗當發送訊息時，訊息時間戳記會導致組件重新渲染同訊息跳動嘅問題

增強功能：
- 修改咗時間戳記鍵嘅生成方式，使用基於時間間隔嘅更穩定嘅計算，以防止唔必要嘅重新渲染

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix message timestamp rendering to prevent unnecessary component refreshes and message jumping

Bug Fixes:
- Resolve an issue where message timestamps cause component re-rendering and message jumping when messages are sent

Enhancements:
- Modify timestamp key generation to use a more stable calculation based on time intervals to prevent unnecessary re-renders

</details>