### PR TITLE
[fix]最近的聊天记录内没有QQ群的bug

### DIFF
--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -1074,7 +1074,7 @@ const msgFunctons = {
             back.forEach((item) => {
                 // 去消息列表里找一下它
                 const user = runtimeData.userList.find((user) => {
-                    return user.user_id == item.user_id
+                    return user.user_id == item.user_id || user.group_id == item.user_id
                 })
                 const inMsgList =
                     runtimeData.onMsgList.find((msg) => {


### PR DESCRIPTION
修改处的`item.user_id`包括了用户的qq号和群组的qq号，这里并未匹配群组qq号，导致最近的聊天记录里面只有qq用户，没有qq群组

## Sourcery 嘅摘要

Bug 修正：
- 修改咗用戶匹配嘅條件，喺搵最近嘅聊天記錄嗰陣，同時包括用戶 ID 同埋群組 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Modify the user matching condition to include both user IDs and group IDs when searching for recent chat records

</details>