### PR TITLE
[fix]关闭群收纳盒功能 不能及时更新聊天记录内信息

### DIFF
--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -56,6 +56,7 @@ import {
 } from './elements/information'
 import { NotifyInfo } from './elements/system'
 import { Notify } from './notify'
+import option from "./option"
 
 const popInfo = new PopInfo()
 // eslint-disable-next-line
@@ -1085,6 +1086,9 @@ const msgFunctons = {
                     updateLastestHistory(user)
                 }
             })
+
+            // 若开启收纳盒功能 则将相应群组放入收纳盒
+            option.clearGroupAssist(runtimeData.sysConfig.bubble_sort_user)
         }
     },
 

--- a/src/renderer/src/function/option.ts
+++ b/src/renderer/src/function/option.ts
@@ -651,4 +651,6 @@ export default {
     runAS,
     runASWEvent,
     remove,
+    clearGroupAssist,
+    groupAssistFunction
 }

--- a/src/renderer/src/function/option.ts
+++ b/src/renderer/src/function/option.ts
@@ -66,7 +66,16 @@ const configFunction: { [key: string]: (value: any) => void } = {
 }
 
 function clearGroupAssist(value: boolean) {
-    if(!value) {
+    // true 为关闭收纳盒，false 为打开收纳盒
+    groupAssistFunction(!value)
+}
+/**
+ * 切换收纳盒状态
+ * @param value 是否打开收纳盒
+ */
+function groupAssistFunction(value: boolean) {
+    if(value) {
+        // 打开收纳盒
         // 将 onMsgList 中的非置顶、没有开启消息通知的群挪到 GroupAssistList 里
         const noticeInfo = OptionFun.get('notice_group') ?? {}
         const noticeGroupIdList = noticeInfo[runtimeData.loginInfo.uin]
@@ -90,6 +99,24 @@ function clearGroupAssist(value: boolean) {
         })
         const sortedList = orderOnMsgList(newList)
         runtimeData.groupAssistList = sortedList
+    } else {
+        // 关闭收纳盒
+        // 将收纳盒中的群挪到 onMsgList 里
+        const groupAssistIdList = runtimeData.groupAssistList.map((item) => {
+            return item.group_id
+        })
+        const newList = runtimeData.groupAssistList.filter((item) => {
+            return groupAssistIdList.includes(item.group_id)
+        })
+        // 删除 groupAssistList 中的这些群
+        runtimeData.groupAssistList = runtimeData.groupAssistList.filter((item) => {
+            return !groupAssistIdList.includes(item.group_id)
+        })
+        // 将这些群添加到 onMsgList 中
+        runtimeData.onMsgList = runtimeData.onMsgList.concat(newList)
+        // 对 onMsgList 进行排序
+        const sortedList = orderOnMsgList(runtimeData.onMsgList)
+        runtimeData.onMsgList = sortedList
     }
 }
 


### PR DESCRIPTION
打开或关闭群收纳盒功能 仅处理了打开群收纳盒时将群组放入收纳盒 

而没有处理关闭收纳盒后 将群组再放回聊天记录的逻辑

此处修复了关闭收纳盒后功能

## Sourcery 嘅摘要

Implement group assistant (收納盒) 功能嘅完整功能，加返啲邏輯去喺停用個功能嗰陣將啲 group 搬返去主聊天列表

Bug Fixes:
- 加返啲邏輯去喺停用 group assistant mode 嗰陣將啲 group 還原返去主聊天列表，解決咗 group assistant 功能唔完整嘅問題

Enhancements:
- 透過喺主聊天列表同 group assistant list 之間實現雙向 group 移動，改進咗 group 管理

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement full functionality for group assistant (收纳盒) feature, adding logic to move groups back to main chat list when disabling the feature

Bug Fixes:
- Fixed incomplete group assistant feature by adding logic to restore groups to the main chat list when disabling the group assistant mode

Enhancements:
- Improved group management by implementing bidirectional group movement between main chat list and group assistant list

</details>