### PR TITLE
设置自动连接不生效，似乎是少了配置

### DIFF
--- a/src/renderer/src/function/option.ts
+++ b/src/renderer/src/function/option.ts
@@ -38,6 +38,7 @@ export const optDefault: { [key: string]: any } = {
     top_info: {},
     save_password: '',
     notice_group: {},
+    auto_connect: false, 
     // View
     language: 'zh-CN',
     opt_dark: false,


### PR DESCRIPTION
由 f2be1b8 引入

## Sourcery 嘅摘要

新功能：
- 喺應用程式嘅預設選項入面，引入一個新嘅配置選項 'auto_connect'，預設值係 false

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce a new configuration option 'auto_connect' with a default value of false in the application's default options

</details>