### PR TITLE
fix connector.ts: 使用URI编码token

### DIFF
--- a/src/main/function/connector.ts
+++ b/src/main/function/connector.ts
@@ -35,7 +35,7 @@ export class Connector {
 
         if (!this.websocket) {
             this.logger.info('正在连接到：', url)
-            this.websocket = new WebSocket(url + '?access_token=' + token)
+            this.websocket = new WebSocket(`${url}?access_token=${encodeURIComponent(token)}`)
         } else {
             // 如果前端发起了连接请求，说明前端在未连接状态；断开已有连接，重新连接
             // PS：这种情况一般不会发生，大部分情况是因为 debug 模式前端热重载导致的


### PR DESCRIPTION
用的带符号的token导致找了半天的bug，从napcat找到服务器防火墙，结果是这个问题（

## Sourcery 嘅摘要

Bug Fixes:
- 當建構 WebSocket URL 嘅時候，將 access token 做 URI 編碼，噉樣就可以用特殊字元嘞

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- URI-encode the access token when constructing the WebSocket URL to allow special characters

</details>