### PR TITLE
fix: 判断[已删除]时未判断该消息是否是message消息

### DIFF
--- a/src/renderer/src/function/utils/msgUtil.ts
+++ b/src/renderer/src/function/utils/msgUtil.ts
@@ -711,8 +711,8 @@ export function isShowTime(
  * @param msg
  */
 export function isDeleteMsg(msg: any): boolean {
-    console.log(runtimeData.sysConfig.dont_parse_delete)
     if(runtimeData.sysConfig.dont_parse_delete === true)return false
+    if(!['message', 'message_sent'].includes(msg.post_type)) return false
     if(msg.sender.user_id !== runtimeData.loginInfo.uin)return false
     if(msg.raw_message !== '&#91;已删除&#93;')return false
     return true


### PR DESCRIPTION
很抱歉写代码遗留下这么大的错误，再pr交上去后才发现

## Sourcery 嘅摘要

精煉 `isDeleteMsg` 嘅邏輯，淨係喺真嘅訊息事件度標記刪除，同埋移除 debug logging

Bug 修正：
- 喺 `isDeleteMsg` 入面加 `post_type` 檢查，忽略非訊息事件
- 喺 `isDeleteMsg` 入面移除唔應該有嘅 `console.log` 呼叫

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine isDeleteMsg logic to only flag deletions on actual message events and remove debug logging

Bug Fixes:
- Add post_type check in isDeleteMsg to ignore non-message events
- Remove stray console.log call in isDeleteMsg

</details>