### PR TITLE
对lgr的一些api支持

### DIFF
--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1238,3 +1238,6 @@ msgstr ""
 
 msgid "确认禁言？"
 msgstr ""
+
+msgid "确认修改头衔？"
+msgstr ""

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1235,3 +1235,6 @@ msgstr ""
 
 msgid "正在确认操作……"
 msgstr ""
+
+msgid "确认禁言？"
+msgstr ""

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1226,3 +1226,12 @@ msgstr ""
 
 msgid "注册时间"
 msgstr ""
+
+msgid "确认修改昵称？"
+msgstr ""
+
+msgid "确认"
+msgstr ""
+
+msgid "正在确认操作……"
+msgstr ""

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1217,3 +1217,12 @@ msgstr ""
 
 msgid "这条消息迷失在虚空里了"
 msgstr ""
+
+msgid "等级"
+msgstr ""
+
+msgid "这个人很懒什么都没有写～"
+msgstr ""
+
+msgid "注册时间"
+msgstr ""

--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -153,3 +153,6 @@ set_group_nickname:
 # 退出群聊
 leave_group:
     name: set_group_leave
+# 设置群名
+set_group_name:
+    name: set_group_name

--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -77,3 +77,29 @@ group_notices:
         img_id: $.message.images.0.id
         is_read: null
         read_num: null
+# 获取群文件主列表
+group_files:
+    name: get_group_root_files
+    source: $.data.*[*]
+    list:
+        # 文件类型
+        file_id: /file_id                        # 文件 ID
+        file_name: /file_name                    # 文件名
+        size: /file_size                         # 文件大小
+        download_times: /download_times          # 下载次数
+        dead_time: /dead_time                    # 过期时间
+        upload_time: /modify_time                # 上传时间
+        uploader_name: /uploader_name            # 上传者
+        # 文件夹类型
+        folder_id: /folder_id                    # 文件夹 ID
+        folder_name: /folder_name                # 文件夹名
+        count: /total_file_count                 # 文件数量
+        create_time: /create_time                # 创建时间
+        creater_name: /create_name               # 创建者
+# 获取群文件下载连接
+file_download:
+    name: get_group_file_url
+    file_url: $.data.url
+# 获取群文件夹内文件
+group_folder_files:
+    name: get_group_files_by_folder

--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -162,3 +162,6 @@ ban_mumber:
 # 设置群头衔（包括成员）
 set_group_title:
     name: set_group_special_title
+# 设置消息回应
+send_respond:
+    name: set_group_reaction

--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -148,3 +148,5 @@ group_member_info:
         is_robot: /is_robot
         shut_up_timestamp: /shut_up_timestamp
         role: /role
+set_group_nickname:
+    name: set_group_card

--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -132,3 +132,19 @@ friend_info:
         birthday_day: null              # 生日日期
         age: /age                       # 年龄
         sex: /sex                       # 性别
+# 获取群成员信息
+group_member_info:
+    name: get_group_member_info
+    source: $.data
+    list:
+        group_id: /group_id
+        user_id: /user_id
+        nickname: /nickname
+        card: /card
+        sex: /sex
+        age: /age
+        join_time: /join_time
+        last_sent_time: /last_sent_time
+        is_robot: /is_robot
+        shut_up_timestamp: /shut_up_timestamp
+        role: /role

--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -103,3 +103,15 @@ file_download:
 # 获取群文件夹内文件
 group_folder_files:
     name: get_group_files_by_folder
+# 获取群精华消息
+group_essence:
+    name: get_essence_msg_list
+    source: $.data[*]
+    list:
+        sender_uin: /sender_id
+        sender_nick: /sender_nick
+        sender_time: /sender_time
+        content: /content
+        add_digest_uin: /operator_id
+        add_digest_nick: /operator_nick
+        add_digest_time: /operator_time

--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -150,3 +150,6 @@ group_member_info:
         role: /role
 set_group_nickname:
     name: set_group_card
+# 退出群聊
+leave_group:
+    name: set_group_leave

--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -159,3 +159,6 @@ set_group_name:
 # 禁言成员
 ban_mumber:
     name: set_group_ban
+# 设置群头衔（包括成员）
+set_group_title:
+    name: set_group_special_title

--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -156,3 +156,6 @@ leave_group:
 # 设置群名
 set_group_name:
     name: set_group_name
+# 禁言成员
+ban_mumber:
+    name: set_group_ban

--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -115,3 +115,20 @@ group_essence:
         add_digest_uin: /operator_id
         add_digest_nick: /operator_nick
         add_digest_time: /operator_time
+# 群/好友信息
+friend_info:
+    name: get_stranger_info
+    source: $.data
+    list:
+        longNick: /sign                 # 签名
+        qid: /q_id                      # 个性 QQ 账号
+        country: null                   # 国家
+        province: null                  # 省份
+        city: null                      # 城市
+        regTime: /RegisterTime          # 注册时间
+        qqLevel: /level                 # QQ 等级
+        birthday_year: null             # 生日年份
+        birthday_month: null            # 生日月份
+        birthday_day: null              # 生日日期
+        age: /age                       # 年龄
+        sex: /sex                       # 性别

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -737,6 +737,7 @@ const msgFunctions = {
         // runtimeData.chatInfo.info.user_info =
         //     msg.data.data.result.buddy.info_list[0]
         const data = getMsgData('friend_info', msg, msgPath.friend_info)[0]
+		data.regTime = new Date(data.reg_time).getTime()
         if(data) {
             runtimeData.chatInfo.info.user_info = data
         }

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -1007,12 +1007,15 @@ const msgFunctions = {
     /**
      * 获取群成员更多信息
      */
-    getGroupMemberInfo: (_: string, msg: { [key: string]: any }) => {
+    getGroupMemberInfo: (
+		_: string,
+		msg: { [key: string]: any },
+        echoList: string[],
+	) => {
         if (msg.data != undefined) {
             const data = msg.data
-            const pointInfo = msg.echo.split('_')
-            data.x = pointInfo[1]
-            data.y = pointInfo[2]
+            data.x = echoList[1]
+            data.y = echoList[2]
             runtimeData.chatInfo.info.now_member_info = data
         }
     },

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -1443,8 +1443,10 @@
                     Connector.send(
                         runtimeData.jsonMap.send_respond.name,
                         {
+							group_id: this.chat.show.id,
                             message_id: msgId,
                             emoji_id: String(num),
+							code: String(num),
                         },
                         'SendRespondBack_' + msgId + '_' + num,
                     )

--- a/src/renderer/src/pages/Info.vue
+++ b/src/renderer/src/pages/Info.vue
@@ -74,7 +74,7 @@
                                 )) }}
                             </span>
                         </span>
-                        <span>{{ $t('地区') }}:
+                        <span v-if="chat.info.user_info.country">{{ $t('地区') }}:
                             <span>
                                 {{
                                     `${chat.info.user_info.country}-${


### PR DESCRIPTION
把我这段时间写的对lgrv1的api进行了整理
其中,退出群聊api没测试(怕进进出出tx给我号ban了)
群文件api已知在文件多的情况下会失效

## Sourcery 總結

引入對各種 Lagrange OneBot v1 API 嘅支援，包括群組文件管理、精華訊息、用戶資訊同群組操作，並更新前端邏輯以處理其數據同指令

新功能：
- 新增 API 端點，用於列出群組文件同資料夾、獲取下載 URL，以及獲取群組精華訊息
- 新增 API 端點，用於獲取陌生人（朋友）資訊同群組成員資訊
- 新增 API 支援群組操作：設置群組名片、重命名群組、封禁成員、分配群頭銜、退出群組，以及發送訊息反應

改進：
- 喺朋友資訊回應中正規化註冊時間
- 更新群組成員資訊處理器，使用 echoList 參數處理座標數據
- 發送反應時包含 group_id 同 code
- 僅喺可用時，喺用戶資訊中條件性地渲染地區（region）字段

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce support for various Lagrange OneBot v1 APIs including group file management, essence messages, user info, and group operations, and update frontend logic to handle their data and commands

New Features:
- Add API endpoints for listing group files and folders, retrieving download URLs, and fetching group essence messages
- Add API endpoints for fetching stranger (friend) info and group member info
- Add API support for group operations: setting group cards, renaming groups, banning members, assigning group titles, leaving groups, and sending message reactions

Enhancements:
- Normalize registration time in friend info response
- Update group member info handler to use echoList parameters for coordinate data
- Include group_id and code when sending reactions
- Conditionally render region field in user info only when available

</details>