### PR TITLE
pref: 优化明暗时彩色的颜色,黑暗模式时更亮,明亮模式更暗

### DIFF
--- a/src/renderer/public/css/append-dark.css
+++ b/src/renderer/public/css/append-dark.css
@@ -1,7 +1,7 @@
 :root {
-    --color-blue: #316cf4;
-    --color-green: #408558;
-    --color-red: #cb444a;
+    --color-blue: #6291fd;
+    --color-green: #6cd892;
+    --color-red: #f56269;
     --color-yellow: #f6c344;
 
     --color-bg-blue: #393e47;

--- a/src/renderer/public/css/append-light.css
+++ b/src/renderer/public/css/append-light.css
@@ -2,7 +2,7 @@
     --color-blue: #316cf4;
     --color-green: #408558;
     --color-red: #cb444a;
-    --color-yellow: #f6c344;
+    --color-yellow: #d68100;
 
     --color-bg-blue: #d3e1fc;
     --color-bg-green: #d5e6de;


### PR DESCRIPTION
之前管理员哪里绿色太暗了,不能比较好的衬托出黑字,干脆调整下css
<div style="display:flex">
<img width="400"  alt="图片" src="https://github.com/user-attachments/assets/07bc9017-b823-49fc-b7b8-db0204933eb6" />

<img width="400" alt="图片" src="https://github.com/user-attachments/assets/ee4c49fe-2ad7-4bbf-b658-14f7bd2b1839" />
</div>

## Sourcery 總結

改善用戶介面顏色對比度，透過在深色模式中提亮核心主題顏色，並在淺色模式中加深黃色

改進：
- 調整 blue、green 和 red CSS 變數，使其在深色模式中更亮
- 加深 yellow CSS 變數在淺色模式中的顏色，以獲得更好的對比度

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve color contrast in the UI by brightening core theme colors in dark mode and darkening yellow in light mode

Enhancements:
- Adjust blue, green, and red CSS variables to be brighter in dark mode
- Darken the yellow CSS variable in light mode for better contrast

</details>