### PR TITLE
之前累计修的一些bug

### DIFF
--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1217,3 +1217,6 @@ msgstr ""
 
 msgid "这条消息迷失在虚空里了"
 msgstr ""
+
+msgid "空消息"
+msgstr ""

--- a/src/renderer/src/components/BulletinBody.vue
+++ b/src/renderer/src/components/BulletinBody.vue
@@ -54,6 +54,7 @@
     import { runtimeData } from '@renderer/function/msg'
     import { openLink } from '@renderer/function/utils/appUtil'
     import { getTrueLang } from '@renderer/function/utils/systemUtil'
+import app from '@renderer/main'
 
     export default defineComponent({
         name: 'BulletinBody',
@@ -103,6 +104,13 @@
                     const link = target.dataset.link
                     openLink(link)
                 }
+            },
+            getSenderName(): string {
+                const { $t } = app.config.globalProperties
+                const result = runtimeData.chatInfo.info.group_members.filter((item) => {
+                    return Number(item.user_id) === Number(this.data.sender)
+                }).at(0)?.nickname
+                return result ?? $t('已退群( {userId} )', { userId: Number(this.data.sender) })
             },
         },
     })

--- a/src/renderer/src/components/MsgBody.vue
+++ b/src/renderer/src/components/MsgBody.vue
@@ -56,7 +56,11 @@
             </a>
             <div>
                 <!-- 消息体 -->
-                <template v-if="!hasCard()">
+                <!-- 消息体 -->
+                <template v-if="data.message.length === 0">
+                    <span class="msg-text" style="opacity: 0.5">{{ $t('空消息') }}</span>
+                </template>
+                <template v-else-if="!hasCard()">
                     <div v-for="(item, index) in data.message"
                         :key="data.message_id + '-m-' + index"
                         :class="View.isMsgInline(item.type) ? 'msg-inline' : ''">

--- a/src/renderer/src/function/elements/information.ts
+++ b/src/renderer/src/function/elements/information.ts
@@ -1,10 +1,12 @@
+import { optDefault } from '../option'
+
 export enum BotMsgType {
     CQCode,
     Array
 }
 
 export interface RunTimeDataElem {
-    sysConfig: { [key: string]: any }
+    sysConfig: Record<keyof typeof optDefault, any|null>
     jsonMap?: any
     botInfo: { [key: string]: any }
     loginInfo: { [key: string]: any }

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -535,8 +535,9 @@
                 <div class="bg" @click="cancelForward" />
             </div>
         </Transition>
-        <div class="bg" :style=" runtimeData.sysConfig.option_view_background ?
-            `backdrop-filter: blur(${runtimeData.sysConfig .chat_background_blur}px);` : ''" />
+        <div class="bg" :style="{
+			'backdrop-filter': `blur(${runtimeData.sysConfig .chat_background_blur}px)`
+			}" />
     </div>
 </template>
 

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -536,8 +536,8 @@
             </div>
         </Transition>
         <div class="bg" :style="{
-			'backdrop-filter': `blur(${runtimeData.sysConfig .chat_background_blur}px)`
-			}" />
+            'backdrop-filter': `blur(${runtimeData.sysConfig .chat_background_blur}px)`
+        }" />
     </div>
 </template>
 

--- a/src/renderer/src/pages/Friends.vue
+++ b/src/renderer/src/pages/Friends.vue
@@ -23,9 +23,9 @@
                     class="small">
                     <label>
                         <input
-							v-auto-focus
-							id="friend-search-small"
-                            v-model="searchInfo" type="text"
+                            id="friend-search-small"
+                            v-model="searchInfo"
+                            v-auto-focus type="text"
                             :placeholder="$t('搜索 ……')" @input="search">
                         <font-awesome-icon :icon="['fas', 'magnifying-glass']" />
                     </label>
@@ -38,10 +38,10 @@
                 </div>
                 <label>
                     <input
-						v-auto-focus
-						id="friend-search"
-						v-model="searchInfo"
-						type="text"
+                        id="friend-search"
+                        v-model="searchInfo"
+                        v-auto-focus
+                        type="text"
                         :placeholder="$t('搜索 ……')" @input="search">
                     <font-awesome-icon :icon="['fas', 'magnifying-glass']" />
                 </label>

--- a/src/renderer/src/pages/options/OptDev.vue
+++ b/src/renderer/src/pages/options/OptDev.vue
@@ -600,7 +600,7 @@
                     html: `
                         <header>以下配置将被删除</header>
                         <div style="color: var(--color-red);font-weight: 700;">
-                    ` + needless.join('<br>') + `</div>`,
+                    ` + needless.join('<br>') + '</div>',
                     button: [
                         {
                             text: this.$t('取消'),


### PR DESCRIPTION
## Sourcery 摘要

增強訊息渲染，通過添加對 base64 編碼公告同迷你應用程式連結預覽嘅支持，實現空訊息佔位符，改善公告發送者解析，並重構解析工具同樣式

新功能：
- 添加對 base64 編碼群組公告嘅解碼同顯示
- 處理 `com.tencent.miniapp_01` (Bilibili) 連結，通過獲取最終重定向 URL 並發出頁面預覽
- 為空訊息顯示本地化佔位符
- 在公告視圖中引入 `getSenderName`，用於解析群組成員暱稱並帶有回退機制

改進：
- 重構 `getJSONType` 簽名以接受訊息卡片並調整 JSON 解析
- 提取 `decodeBase64Unicode` 工具，並整合 `callBackend` 和 `linkView` 以處理連結
- 更新 `CardMessage` 以為連結預覽發出頁面查看事件
- 更改 `Chat` 組件 CSS 綁定為對象語法以實現背景模糊
- 收緊 `RunTimeDataElem` 中 `sysConfig` 的類型，以使用 `optDefault` 鍵

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance message rendering by adding support for base64-encoded announcements and miniapp link previews, implement empty-message placeholders, improve bulletin sender resolution, and refactor parsing utilities and styling

New Features:
- Add decoding and display of base64-encoded group announcements
- Handle com.tencent.miniapp_01 (Bilibili) links by fetching final redirect URL and emitting page-view previews
- Show a localized placeholder for empty messages
- Introduce getSenderName in bulletin view to resolve group member nicknames with a fallback

Enhancements:
- Refactor getJSONType signature to accept a message card and adjust JSON parsing
- Extract decodeBase64Unicode utility and integrate callBackend and linkView for link handling
- Update CardMessage to emit page-view events for link previews
- Change Chat component CSS binding to object syntax for background blur
- Tighten sysConfig typing in RunTimeDataElem to use optDefault keys

</details>