### PR TITLE
pref: 更好的自动聚焦

### DIFF
--- a/src/renderer/src/function/utils/appUtil.ts
+++ b/src/renderer/src/function/utils/appUtil.ts
@@ -20,7 +20,7 @@ import {
     rgbToHsl,
     addBackendListener
 } from '@renderer/function/utils/systemUtil'
-import { toRaw, nextTick } from 'vue'
+import { toRaw, nextTick, Directive } from 'vue'
 import { sendMsgRaw } from './msgUtil'
 import { parseMsg } from '../sender'
 import { Notify } from '../notify'
@@ -1067,3 +1067,50 @@ export function changeGroupNotice(group_id: number, open: boolean) {
         option.save('notice_group', noticeInfo)
     }
 }
+
+/**
+ * 是否应该自动聚焦输入框
+ * @returns
+ */
+export function shouldAutoFocus(): boolean {
+    // 桌面端
+    if (runtimeData.tags.clientType !== 'web') {
+        // 除了苹果的不知道啥东西,都可以
+        if (['electron', 'tauri'].includes(runtimeData.tags.clientType)) {
+            return true
+        }
+        return false
+    }
+    // web端
+    else {
+        // 移动端浏览器不自动聚焦
+        if (/Mobile|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+            return false
+        }
+        return true
+    }
+}
+
+//#region == v命令封装 ======================================
+/**
+ * 挂在时如果设备支持,自动聚焦输入框
+ */
+export const vAutoFocus: Directive<HTMLInputElement|HTMLTextAreaElement, undefined> = {
+    mounted(el: HTMLInputElement|HTMLTextAreaElement) {
+        // 判断是否支持聚焦
+        if (!shouldAutoFocus()) return
+
+        // 检查元素是否可见
+        const isVisible = () => {
+            const style = window.getComputedStyle(el)
+            return style.display !== 'none' &&
+                   style.visibility !== 'hidden' &&
+                   style.opacity !== '0'
+        }
+
+        if (!isVisible()) return
+
+        el.focus()
+    }
+}
+//#endregion

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -556,6 +556,7 @@
     import {
         downloadFile,
         loadHistory as loadHistoryFirst,
+		shouldAutoFocus,
     } from '@renderer/function/utils/appUtil'
     import {
         addBackendListener,
@@ -1969,7 +1970,7 @@
                             'setMessageRead',
                         )
                     }
-                    if(['electron', 'tauri'].includes(runtimeData.tags.clientType)) {
+                    if(shouldAutoFocus()) {
                         // 将焦点移动到发送框
                         this.toMainInput()
                     }

--- a/src/renderer/src/pages/Friends.vue
+++ b/src/renderer/src/pages/Friends.vue
@@ -22,7 +22,9 @@
                     id="friend-small-search"
                     class="small">
                     <label>
-                        <input id="friend-search-small"
+                        <input
+							v-auto-focus
+							id="friend-search-small"
                             v-model="searchInfo" type="text"
                             :placeholder="$t('搜索 ……')" @input="search">
                         <font-awesome-icon :icon="['fas', 'magnifying-glass']" />
@@ -35,7 +37,11 @@
                     </div>
                 </div>
                 <label>
-                    <input id="friend-search" v-model="searchInfo" type="text"
+                    <input
+						v-auto-focus
+						id="friend-search"
+						v-model="searchInfo"
+						type="text"
                         :placeholder="$t('搜索 ……')" @input="search">
                     <font-awesome-icon :icon="['fas', 'magnifying-glass']" />
                 </label>
@@ -131,6 +137,9 @@
     </div>
 </template>
 
+<script setup lang="ts">
+	import { vAutoFocus } from '@renderer/function/utils/appUtil'
+</script>
 <script lang="ts">
     import FriendBody from '@renderer/components/FriendBody.vue'
 
@@ -144,7 +153,7 @@
     import { runtimeData } from '@renderer/function/msg'
     import { reloadUsers } from '@renderer/function/utils/appUtil'
     import { login as loginInfo } from '@renderer/function/connect'
-import { callBackend } from '@renderer/function/utils/systemUtil'
+	import { callBackend } from '@renderer/function/utils/systemUtil'
 
     export default defineComponent({
         name: 'ViewFriends',


### PR DESCRIPTION
## Sourcery 總結

新增一個統一嘅自動對焦工具同 Vue 指令，嚟標準化桌面同網頁平台嘅輸入框對焦，並將佢應用到搜尋同聊天輸入框。

改進：
- 新增 `shouldAutoFocus` 函數，嚟判斷基於客戶端類型同用戶代理嘅對焦資格
- 引入 `vAutoFocus` 指令，當組件掛載時自動對焦可見嘅 `input` 同 `textarea` 元素
- 將 `v-auto-focus` 指令應用到 `Friends.vue` 中嘅朋友搜尋輸入框
- 喺 `Chat.vue` 中用 `shouldAutoFocus` 替代手動嘅 `clientType` 檢查，嚟對焦聊天輸入框

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a unified auto-focus utility and Vue directive to standardize input focusing across desktop and web platforms, and apply it to search and chat input fields.

Enhancements:
- Add shouldAutoFocus function to determine focus eligibility based on client type and user agent
- Introduce vAutoFocus directive to automatically focus visible input and textarea elements when mounted
- Apply v-auto-focus directive to friend search inputs in Friends.vue
- Replace manual clientType checks with shouldAutoFocus in Chat.vue to focus the chat input

</details>