### PR TITLE
开发环境不再自动移除未时用的配置,改为在配置中手动移除

### DIFF
--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1217,3 +1217,9 @@ msgstr ""
 
 msgid "这条消息迷失在虚空里了"
 msgstr ""
+
+msgid "移除未使用的配置"
+msgstr ""
+
+msgid "sudo rm -rf /etc"
+msgstr ""

--- a/src/renderer/src/function/option.ts
+++ b/src/renderer/src/function/option.ts
@@ -457,6 +457,7 @@ function loadOptData(data: { [key: string]: any }) {
 		new PopInfo().add(
 			PopType.INFO,
 			'发现' + needless.length + '条未使用的配置属性',
+			false,
 		)
 	}
     

--- a/src/renderer/src/function/option.ts
+++ b/src/renderer/src/function/option.ts
@@ -444,12 +444,22 @@ function loadOptData(data: { [key: string]: any }) {
         }
     })
     // 删除不存在的设置项
-    Object.keys(options).forEach((key) => {
-        if (optDefault[key] === undefined) {
-            optChanged = true
-            delete options[key]
-        }
-    })
+	const needless: string[] = []
+	for (const key in options) {
+		if (optDefault[key] === undefined)
+			needless.push(key)
+	}
+    if (!import.meta.env.DEV){
+        for (const key of needless) {
+			delete options[key]
+		}
+    }else if (needless.length > 0) {
+		new PopInfo().add(
+			PopType.INFO,
+			'发现' + needless.length + '条未使用的配置属性',
+		)
+	}
+    
     // 保存
     if (optChanged) {
         saveAll(options)

--- a/src/renderer/src/pages/options/OptDev.vue
+++ b/src/renderer/src/pages/options/OptDev.vue
@@ -125,6 +125,17 @@
                 <input v-model="appmsg_text" class="ss-input"
                     style="width: 150px" type="text" @keyup="sendTestAppmsg">
             </div>
+            <div v-if="dev" class="opt-item">
+                <font-awesome-icon :icon="['fas', 'trash']" />
+                <div>
+                    <span>{{ $t('移除未使用的配置') }}</span>
+                    <span>{{ $t('sudo rm -rf /etc') }}</span>
+                </div>
+                <button style="width: 100px; font-size: 0.8rem"
+                    class="ss-button" @click="rmNeedlessOption">
+                    {{ $t('执行') }}
+                </button>
+            </div>
             <div class="opt-item">
                 <font-awesome-icon :icon="['fas', 'file-invoice']" />
                 <div>
@@ -213,6 +224,7 @@
         runASWEvent as save,
         saveAll,
         checkDefault,
+        optDefault,
     } from '@renderer/function/option'
     import { Connector } from '@renderer/function/connect'
     import { PopInfo, PopType } from '@renderer/function/base'
@@ -221,12 +233,13 @@
     import { BotMsgType } from '@renderer/function/elements/information'
     import { uptime } from '@renderer/main'
     import { loadJsonMap } from '@renderer/function/utils/appUtil'
-import { callBackend } from '@renderer/function/utils/systemUtil'
+    import { callBackend } from '@renderer/function/utils/systemUtil'
 
     export default defineComponent({
         name: 'ViewOptDev',
         data() {
             return {
+                dev: import.meta.env.DEV,
                 jsonMapName: runtimeData.jsonMap?.name ?? '',
 
                 checkDefault: checkDefault,
@@ -566,6 +579,49 @@ import { callBackend } from '@renderer/function/utils/systemUtil'
             changeJsonMap() {
                 const getPath = loadJsonMap(this.jsonMapName)
                 if (getPath) runtimeData.jsonMap = getPath
+            },
+            // 查看配置文件
+            rmNeedlessOption() {
+                const needless: string[] = []
+                for (const key of Object.keys(runtimeData.sysConfig)) {
+                    if (optDefault[key] === undefined) {
+                        needless.push(key)
+                    }
+                }
+                if (needless.length === 0) {
+                    new PopInfo().add(
+                        PopType.INFO,
+                        this.$t('没有需要删除的配置项'),
+                    )
+                    return
+                }
+                const popInfo = {
+                    title: this.$t('转发消息'),
+                    html: `
+                        <header>以下配置将被删除</header>
+                        <div style="color: var(--color-red);font-weight: 700;">
+                    ` + needless.join('<br>') + `</div>`,
+                    button: [
+                        {
+                            text: this.$t('取消'),
+                            master: true,
+                            fun: () => {
+                                runtimeData.popBoxList.shift()
+                            },
+                        },
+                        {
+                            text: this.$t('确定'),
+                            fun: () => {
+                                for (const key of needless) {
+                                    delete runtimeData.sysConfig[key]
+                                }
+                                saveAll(runtimeData.sysConfig)
+                                runtimeData.popBoxList.shift()
+                            },
+                        },
+                    ],
+                }
+                runtimeData.popBoxList.push(popInfo)
             },
         },
     })


### PR DESCRIPTION
淦,我且了下版本配置文件可被删了...

## Sourcery 摘要

在開發模式下引入手動移除未使用的系統配置，並調整配置加載器，使其在開發版本中禁用自動清理，同時在生產環境中保留此功能。

新功能：
- 在開發選項用戶界面中添加「移除未使用的配置」按鈕，並帶有確認對話框

改進：
- 在開發中停止自動刪除未識別的配置鍵，並顯示一個警告列出它們
- 在生產環境中繼續自動移除未使用的配置條目

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce manual removal of unused system configuration in development mode and adjust the config loader to disable automatic cleanup in dev builds while preserving it in production.

New Features:
- Add “Remove unused configuration” button in the development options UI with a confirmation dialog

Enhancements:
- Stop automatically deleting unrecognized config keys in development and display a warning listing them
- Continue auto-removal of unused configuration entries in production environments

</details>