### PR TITLE
fix: 机器人判定异常

### DIFF
--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -145,7 +145,6 @@ group_member_info:
         age: /age
         join_time: /join_time
         last_sent_time: /last_sent_time
-        is_robot: /is_robot
         shut_up_timestamp: /shut_up_timestamp
         role: /role
 set_group_nickname:

--- a/src/renderer/src/assets/pathMap/NapCat.Onebot.yaml
+++ b/src/renderer/src/assets/pathMap/NapCat.Onebot.yaml
@@ -147,7 +147,6 @@ group_member_info:
         age: /age
         join_time: /join_time
         last_sent_time: /last_sent_time
-        is_robot: /is_robot
         shut_up_timestamp: /shut_up_timestamp
         role: /role
 # 获取收藏表情

--- a/src/renderer/src/components/MsgBody.vue
+++ b/src/renderer/src/components/MsgBody.vue
@@ -34,7 +34,7 @@
         </div>
         <div :class="isMe ? type == 'merge' ? 'message-body' : 'message-body me' : 'message-body'">
             <template v-if="runtimeData.chatInfo.show.type == 'group' && !isMe">
-                <span v-if="senderInfo?.is_robot" class="robot">{{ $t('机器人') }}</span>
+                <span v-if="senderInfo && isRobot(senderInfo.user_id)" class="robot">{{ $t('机器人') }}</span>
                 <span v-if="senderInfo?.role == 'owner'" class="owner">{{ $t('群主') }}</span>
                 <span v-else-if="senderInfo?.role == 'admin'" class="admin">{{ $t('管理员') }}</span>
                 <span v-if="senderInfo?.title && senderInfo?.title != ''">{{ senderInfo?.title.replace(/[\u202A-\u202E\u2066-\u2069]/g, '') }}</span>
@@ -363,6 +363,7 @@ import { Logger, LogType, PopInfo, PopType } from '@renderer/function/base'
 import { StringifyOptions } from 'querystring'
 import { getFace, getMsgRawTxt, pokeAnime } from '@renderer/function/utils/msgUtil'
 import {
+    isRobot,
     openLink,
     sendStatEvent,
 } from '@renderer/function/utils/appUtil'

--- a/src/renderer/src/function/utils/appUtil.ts
+++ b/src/renderer/src/function/utils/appUtil.ts
@@ -1093,6 +1093,20 @@ export function shouldAutoFocus(): boolean {
     }
 }
 
+/**
+ * 判断是不是机器人
+ * @param id 用户id
+ * @returns
+ */
+export function isRobot(id: number | string): boolean {
+    id = Number(id)
+    if (id >= 4010000000 && id <= 4019999999) return true
+    if (id >= 2854196301 && id <= 2854216399) return true
+    if (id >= 3889000000 && id <= 3889999999) return true
+    if (id === 66600000) return true
+    return false
+}
+
 //#region == use封装 ========================================
 /**
  * 用来封装一个停留事件的处理, 支持传递额外上下文


### PR DESCRIPTION
现在至少lgr已经不返回是否是机器人了。机器人可以根据uin进行判断
<img width="316" height="198" alt="图片" src="https://github.com/user-attachments/assets/5dc91f7e-0f31-456d-952c-6ef4450dc642" />

## Sourcery 摘要

透過 UIN 範圍推斷機器人用戶，而唔再依賴已棄用嘅 `is_robot` 字段，並更新 UI 檢查同移除過時嘅映射。

錯誤修復：
- 修復錯誤嘅機器人檢測，將檢測方式由缺失嘅 `is_robot` 屬性切換到基於 UIN 嘅邏輯。

功能增強：
- 引入 `isRobot` 工具函數，用於從用戶 ID 判斷機器人狀態。

雜項：
- 從 OneBot YAML 配置檔案中移除 `is_robot` 字段映射。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Infer robot users by UIN ranges instead of relying on the deprecated is_robot field, updating UI checks and removing the obsolete mapping.

Bug Fixes:
- Fix incorrect robot detection by switching from the missing is_robot property to UIN-based logic.

Enhancements:
- Introduce isRobot utility function to determine robot status from user IDs.

Chores:
- Remove is_robot field mappings from OneBot YAML configuration files.

</details>