### PR TITLE
pref: 优化at用户信息栏，改为触碰头像也可以触发，触发有0.5s的停留延迟，增加出现动画。以及右出界处理

### DIFF
--- a/src/renderer/src/assets/css/chat.css
+++ b/src/renderer/src/assets/css/chat.css
@@ -487,57 +487,64 @@ input {
     display: flex;
 }
 
-.mumber-info {
+.member-info {
     position: absolute;
+    top: 0px;
+    left: 0px;
     height: calc(100% - var(--safe-area-bottom));
     width: 100%;
+    z-index: 10;
+    pointer-events: none;
 }
-.mumber-info span,
-.mumber-info a {
+.member-info span,
+.member-info a {
     color: var(--color-font);
 }
-.mumber-info > div {
-    pointer-events: all;
+.member-info > div {
+    pointer-events: none;
 }
-.mumber-info > div:first-child {
+.member-info > div:first-child {
     transform: translate(-20px, calc(-100% - 0.8rem));
     box-shadow: 0 0 5px var(--color-shader);
-    background: rgba(var(--color-card-2-rgb), 0.5);
+    background: rgba(var(--color-card-2-rgb), 0.75);
     border: 1px solid var(--color-card-2);
     backdrop-filter: blur(15px);
     padding: 10px 20px 10px 10px;
     width: fit-content;
     overflow: hidden;
     max-width: 55%;
+
+}
+.member-info > div:first-child > div:nth-child(1) {
     display: flex;
 }
-.mumber-info > div:first-child img {
+.member-info > div:first-child > div:nth-child(1) > img {
     outline: 2px solid var(--color-main);
     border-radius: 7px;
     height: 60px;
     width: 60px;
 }
-.mumber-info > div:first-child > div {
+.member-info > div:first-child > div:nth-child(1) > div {
     margin-left: 20px;
     overflow: hidden;
     flex: 1;
 }
-.mumber-info > div:first-child > div > span {
+.member-info > div:first-child > div:nth-child(1) > div > span {
     color: var(--color-font-1);
     font-size: 0.9rem;
     white-space: nowrap;
 }
-.mumber-info > div:first-child > div > span[name='id'] {
+.member-info > div:first-child > div:nth-child(1) > div > span[name='id'] {
     font-size: 0.8rem;
     display: block;
-    opacity: 0.5;
+    opacity: 0.7
 }
-.mumber-info > div:first-child > div > div {
+.member-info > div:first-child > div:nth-child(1) > div > div {
     margin-bottom: 5px;
     flex-wrap: wrap;
     display: flex;
 }
-.mumber-info > div:first-child > div > div > a {
+.member-info > div:first-child > div:nth-child(1) > div > div > a {
     text-overflow: ellipsis;
     width: 100%;
     overflow: hidden;
@@ -547,19 +554,22 @@ input {
     font-size: 1rem;
     display: block;
 }
-.mumber-info > div:first-child > div > div > div {
+.member-info > div:first-child > div:nth-child(1) > div > div > div {
     margin-top: 4px;
 }
-.mumber-info > div:first-child > div > div > div > span {
-    background: var(--color-main);
-    color: var(--color-font-r);
-    padding: 2px 10px 2px 10px;
-    border-radius: 2rem;
-    margin-left: 5px;
-    font-size: 0.7rem;
+/* 群成员下边区域 */
+.member-info > div:first-child > div:nth-child(2).member {
+    display: flex;
+    margin-top: 10px;
+    align-items: center;
 }
-.mumber-info > div:first-child > div > div > div > span:first-child {
-    margin-left: 0;
+.member-info > div:first-child > div:nth-child(2).member > :nth-child(1) {
+    width: 60px;
+    display: block;
+    font-size: 13px;
+}
+.member-info > div:first-child > div:nth-child(2).member > :nth-child(2) {
+    margin-left: 20px;
 }
 
 .chat-info-pan {

--- a/src/renderer/src/assets/css/msg.css
+++ b/src/renderer/src/assets/css/msg.css
@@ -494,6 +494,27 @@
     margin-left: 7px;
 }
 
+
+span.user-title {
+    margin-right: 3px;
+    font-size: 0.9rem;
+    height: 1rem;
+    display: inline-block;
+    background: var(--color-main);
+    color: var(--color-font-r);
+    border-radius: 0.5rem;
+    padding: 1px 4px;
+}
+span.user-title.owner {
+    background: var(--color-yellow);
+}
+span.user-title.admin {
+    background: var(--color-green);
+}
+span.user-title.robot {
+    background: var(--color-blue);
+}
+
 .loading {
     opacity: 0.0;
 }

--- a/src/renderer/src/components/MsgBody.vue
+++ b/src/renderer/src/components/MsgBody.vue
@@ -402,7 +402,9 @@ const {
     userInfoPan?: UserInfoPan
 }>()
 
-defineEmits<{
+// 半 setup 半 旧的 api是这样的...旧的emit定义类型太麻烦了...
+// eslint-disable-next-line  @typescript-eslint/no-unused-vars
+const emit = defineEmits<{
     scrollToMsg: [...args: any[]]
     imageLoaded: [...args: any[]]
     sendPoke: [...args: any[]]
@@ -434,7 +436,6 @@ const {
 //#region == 工具函数 ================================================================
 function getAtMember(id: number): IUser | number {
     const re = getUserById(id) ?? id
-    console.log(id, re)
     return re
 }
 function getUserById(id: number): IUser | undefined {
@@ -568,7 +569,7 @@ function getUserById(id: number): IUser | undefined {
              * @param id 消息 id
              */
             scrollToMsg(id: string) {
-                this.$emit('scrollToMsg', 'chat-' + id)
+                emit('scrollToMsg', 'chat-' + id)
             },
 
             /**
@@ -634,7 +635,7 @@ function getUserById(id: number): IUser | undefined {
                 if (imgHeight > vh * 0.35)
                     imgWidth = (imgWidth * (vh * 0.35)) / imgHeight
                 img.style.setProperty('--width', `${imgWidth}px`)
-                this.$emit('imageLoaded', img.offsetHeight)
+                emit('imageLoaded', img.offsetHeight)
             },
 
             /**
@@ -959,7 +960,7 @@ function getUserById(id: number): IUser | undefined {
 
             sendPoke() {
                 // 调用上级组件的 poke 方法
-                this.$emit('sendPoke', this.data.sender.user_id)
+                emit('sendPoke', this.data.sender.user_id)
             },
 
             async showPock() {

--- a/src/renderer/src/components/UserInfoPan.vue
+++ b/src/renderer/src/components/UserInfoPan.vue
@@ -1,4 +1,4 @@
-<!--
+\<!--
  * @FileDescription: 群成员消息悬浮窗
  * @Author: Mr.Lee
  * @Date: 2025/09/01
@@ -8,7 +8,6 @@
     <Teleport to="body">
         <Transition name="member-info">
             <div v-if="data.user" class="member-info" :style="posInfo">
-                {{ console.log(posInfo) }}
                 <!-- 已退群 -->
                 <div v-if="typeof data.user === 'number'"
                     ref="body"
@@ -90,8 +89,6 @@ import {
     Reactive,
     computed,
 } from 'vue';
-
-type IUser = any
 
 const { data } = defineProps<{
     data: {

--- a/src/renderer/src/components/UserInfoPan.vue
+++ b/src/renderer/src/components/UserInfoPan.vue
@@ -1,0 +1,177 @@
+<!--
+ * @FileDescription: 群成员消息悬浮窗
+ * @Author: Mr.Lee
+ * @Date: 2025/09/01
+ * @Version: 1.0
+-->
+<template>
+    <Teleport to="body">
+        <Transition name="member-info">
+            <div v-if="data.user" class="member-info" :style="posInfo">
+                {{ console.log(posInfo) }}
+                <!-- 已退群 -->
+                <div v-if="typeof data.user === 'number'"
+                    ref="body"
+                    class="ss-card leave">
+                    <div>
+                        <img :src="'https://q1.qlogo.cn/g?b=qq&s=0&nk=' + data.user">
+                        <div>
+                            <span name="id">{{ data.user }}</span>
+                            <div>
+                                <a>{{ $t('已退群( {userId} )', { userId: data.user }) }}</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- 群成员 -->
+                <div v-else
+                    ref="body"
+                    class="ss-card">
+                    <div>
+                        <img :src="'https://q1.qlogo.cn/g?b=qq&s=0&nk=' + data.user.user_id">
+                        <div>
+                            <span name="id">{{ data.user.user_id }}</span>
+                            <div>
+                                <a>{{ data.user.card ? data.user.card : data.user.nickname }}</a>
+                                <span :class="titleClass">
+                                    <template v-if="data.user?.is_robot">
+                                        {{ $t('机器人') }}
+                                    </template>
+                                    <template v-if="data.user?.role == 'owner'">
+                                        {{ $t('群主') }}
+                                    </template>
+                                    <template v-if="data.user?.role == 'admin'">
+                                        {{ $t('管理员') }}
+                                    </template>
+                                    <template v-if="data.user?.level">
+                                        {{ 'Lv.' + data.user.level }}
+                                    </template>
+                                </span>
+                                <span v-if="data.user?.is_robot" class="robot">{{ $t('机器人') }}</span>
+                                <span v-if="data.user?.role == 'owner'" class="owner">{{ $t('群主') }}</span>
+                                <span v-else-if="data.user?.role == 'admin'" class="admin">{{ $t('管理员') }}</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="member">
+                        <div>
+                            <template v-if="data.user.banTime">
+                                <font-awesome-icon style="color: var(--color-red)" :icon="['fas', 'fa-volume-mute']" />
+                                {{ $t('禁言中') }}
+                            </template>
+                        </div>
+                        <span v-if="data.user.join_time">
+                            {{
+                                $t('{time} 加入群聊', {
+                                    time: Intl.DateTimeFormat(getTrueLang(), {
+                                        year: 'numeric',
+                                        month: 'short',
+                                        day: 'numeric',
+                                    }).format(
+                                        new Date(data.user.join_time * 1000),
+                                    ),
+                                })
+                            }}
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </Transition>
+    </Teleport>
+</template>
+
+<script setup lang="ts">
+import { getTrueLang } from '@renderer/function/utils/systemUtil';
+import {
+    ref,
+    type Ref,
+    watchEffect,
+    reactive,
+    Reactive,
+    computed,
+} from 'vue';
+
+type IUser = any
+
+const { data } = defineProps<{
+    data: {
+        x: number,
+        y: number,
+        user: IUser|number,
+    }
+}>()
+
+const body: Ref<HTMLElement|undefined> = ref(undefined)
+const posInfo: Reactive<{'--x': string, '--y': string, '--width': string}> = reactive({
+    '--x': '0px',
+    '--y': '0px',
+    '--width': '0px',
+})
+
+const titleClass = computed(()=>{
+    return {
+        'user-title': true,
+        'robot': data.user?.is_robot,
+        'owner': data.user?.role == 'owner',
+        'admin': data.user?.role == 'admin',
+    }
+})
+
+// 切换css
+watchEffect(() => {
+    posInfo['--x'] = data.x + 'px'
+    posInfo['--y'] = data.y + 'px'
+    if (body.value) {
+        posInfo['--width'] = body.value.offsetWidth + 'px'
+    }
+
+    // 出界处理
+    if (!body.value) return
+    // 高度
+    const panHeight = body.value.clientHeight
+    const bodyHeight = document.body.clientHeight
+    if (data.y + panHeight > bodyHeight - 20) {
+        posInfo['--y'] =
+            bodyHeight - panHeight - 10 + 'px'
+    }
+    // 宽度
+    const menuWidth = body.value.clientWidth
+    const bodyWidth = document.body.clientWidth
+    if (data.x + menuWidth > bodyWidth - 20) {
+        posInfo['--x'] =
+            bodyWidth - menuWidth - 10 + 'px'
+    }
+})
+</script>
+
+<script lang="ts">
+type IUser = any
+export interface UserInfoPan {
+    open: (user: IUser | number, x: number, y: number) => void
+    close: () => void
+}
+</script>
+
+<style scoped>
+.member-info {
+    margin-left: var(--x);
+    margin-top: var(--y);
+}
+.member-info-enter-active, .member-info-leave-active {
+    animation: none 0.2s;
+}
+.member-info-enter-active > .ss-card, .member-info-leave-active > .ss-card {
+    transition: all 0.2s;
+}
+.member-info-enter-active > .ss-card, .member-info-leave-active > .ss-card {
+    transform-origin: top;
+}
+.member-info-enter-from > .ss-card, .member-info-leave-to > .ss-card {
+    opacity: 0;
+    transform: scaleY(0) translate(-20px, calc(-100% - 0.8rem));
+}
+.member-info-enter-to > .ss-card, .member-info-leave-from > .ss-card {
+    opacity: 1;
+    transform: scaleY(1) translate(-20px, calc(-100% - 0.8rem));
+}
+</style>

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -1023,22 +1023,6 @@ const msgFunctions = {
     },
 
     /**
-     * 获取群成员更多信息
-     */
-    getGroupMemberInfo: (
-		_: string,
-		msg: { [key: string]: any },
-        echoList: string[],
-	) => {
-        if (msg.data != undefined) {
-            const data = msg.data
-            data.x = echoList[1]
-            data.y = echoList[2]
-            runtimeData.chatInfo.info.now_member_info = data
-        }
-    },
-
-    /**
      * 设置消息已读
      */
     readMemberMessage: (_: string, msg: { [key: string]: any }) => {

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -540,7 +540,6 @@ import {
     shouldAutoFocus,
 } from '@renderer/function/utils/appUtil'
 import {
-    addBackendListener,
     getTimeConfig,
     getTrueLang,
     getViewTime,

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -98,6 +98,7 @@
                         :key="msgIndex.fake_message_id ?? msgIndex.message_id"
                         :selected="multipleSelectList.includes(msgIndex.message_id) || tags.menuDisplay.menuSelectedMsgId == msgIndex.message_id"
                         :data="msgIndex"
+                        :user-info-pan="userInfoPanFunc"
                         @click="msgClick($event, msgIndex)"
                         @show-menu="showMsgMeun"
                         @scroll-to-msg="scrollToMsg"
@@ -131,6 +132,7 @@
                         :key="msgIndex.fake_message_id ?? msgIndex.message_id"
                         :selected="multipleSelectList.includes(msgIndex.message_id) || tags.menuDisplay.menuSelectedMsgId == msgIndex.message_id"
                         :data="msgIndex"
+                        :user-info-pan="userInfoPanFunc"
                         @scroll-to-msg="scrollToMsg"
                         @show-menu="showMsgMeun"
                         @image-loaded="imgLoadedScroll"
@@ -363,38 +365,7 @@
         <!-- 合并转发消息预览器 -->
         <MergePan ref="mergePan" />
         <!-- At 信息悬浮窗 -->
-        <div class="mumber-info">
-            <div v-if="Object.keys(mumberInfo).length > 0 && mumberInfo.error === undefined"
-                class="ss-card"
-                :style="getPopPost()">
-                <img :src="'https://q1.qlogo.cn/g?b=qq&s=0&nk=' + mumberInfo.user_id">
-                <div>
-                    <span name="id">{{ mumberInfo.user_id }}</span>
-                    <div>
-                        <a>{{ mumberInfo.card == '' ? mumberInfo.nickname : mumberInfo.card }}</a>
-                        <div>
-                            <span v-if="mumberInfo.role !== 'member'">
-                                {{ $t('成员类型_' + mumberInfo.role) }}
-                            </span>
-                            <span>Lv {{ mumberInfo.level }}</span>
-                        </div>
-                    </div>
-                    <span v-if="mumberInfo.join_time">
-                        {{
-                            $t('{time} 加入群聊', {
-                                time: Intl.DateTimeFormat(trueLang, {
-                                    year: 'numeric',
-                                    month: 'short',
-                                    day: 'numeric',
-                                }).format(
-                                    new Date(mumberInfo.join_time * 1000),
-                                ),
-                            })
-                        }}
-                    </span>
-                </div>
-            </div>
-        </div>
+        <UserInfoPanComponent :data="userInfoPanData" />
         <!-- 消息右击菜单 -->
         <Teleport to="body">
             <div :class="'msg-menu' + (['linux', 'win32'].includes(runtimeData.tags.platform ?? '') ? ' withBar' : '')">
@@ -545,58 +516,86 @@
     </div>
 </template>
 
-<script lang="ts">
-    import app from '@renderer/main'
-    import SendUtil from '@renderer/function/sender'
-    import Option, { get } from '@renderer/function/option'
-    import Info from '@renderer/pages/Info.vue'
-    import MsgBody from '@renderer/components/MsgBody.vue'
-    import NoticeBody from '@renderer/components/NoticeBody.vue'
-    import FacePan from '@renderer/components/FacePan.vue'
-    import MergePan from '@renderer/components/MergePan.vue'
-    import imageCompression from 'browser-image-compression'
+<script setup lang="ts">
+import app from '@renderer/main'
+import SendUtil from '@renderer/function/sender'
+import Option, { get } from '@renderer/function/option'
+import Info from '@renderer/pages/Info.vue'
+import MsgBody from '@renderer/components/MsgBody.vue'
+import NoticeBody from '@renderer/components/NoticeBody.vue'
+import FacePan from '@renderer/components/FacePan.vue'
+import MergePan from '@renderer/components/MergePan.vue'
+import imageCompression from 'browser-image-compression'
 
-    import { defineComponent, markRaw, reactive } from 'vue'
-    import { v4 as uuid } from 'uuid'
-    import {
-        downloadFile,
-        loadHistory as loadHistoryFirst,
-		shouldAutoFocus,
-    } from '@renderer/function/utils/appUtil'
-    import {
-        addBackendListener,
-        getTimeConfig,
-        getTrueLang,
-        getViewTime,
-    } from '@renderer/function/utils/systemUtil'
-    import {
-        getMsgRawTxt,
-        sendMsgRaw,
-        getFace,
-        getShowName,
-        isShowTime,
-        isDeleteMsg,
-    } from '@renderer/function/utils/msgUtil'
-    import { scrollToMsg } from '@renderer/function/utils/appUtil'
-    import { Logger, LogType, PopInfo, PopType } from '@renderer/function/base'
-    import { Connector } from '@renderer/function/connect'
-    import { runtimeData } from '@renderer/function/msg'
-    import {
-        BaseChatInfoElem,
-        MsgItemElem,
-        SQCodeElem,
-        GroupMemberInfoElem,
-        UserFriendElem,
-        UserGroupElem,
-        MenuEventData,
-    } from '@renderer/function/elements/information'
+import {
+    defineComponent,
+    markRaw,
+    reactive,
+    shallowReactive
+} from 'vue'
+import { v4 as uuid } from 'uuid'
+import {
+    downloadFile,
+    loadHistory as loadHistoryFirst,
+    shouldAutoFocus,
+} from '@renderer/function/utils/appUtil'
+import {
+    addBackendListener,
+    getTimeConfig,
+    getTrueLang,
+    getViewTime,
+} from '@renderer/function/utils/systemUtil'
+import {
+    getMsgRawTxt,
+    sendMsgRaw,
+    getFace,
+    getShowName,
+    isShowTime,
+    isDeleteMsg,
+} from '@renderer/function/utils/msgUtil'
+import { scrollToMsg } from '@renderer/function/utils/appUtil'
+import { Logger, LogType, PopInfo, PopType } from '@renderer/function/base'
+import { Connector } from '@renderer/function/connect'
+import { runtimeData } from '@renderer/function/msg'
+import {
+    BaseChatInfoElem,
+    MsgItemElem,
+    SQCodeElem,
+    GroupMemberInfoElem,
+    UserFriendElem,
+    UserGroupElem,
+    MenuEventData,
+} from '@renderer/function/elements/information'
 import { wheelMask } from '@renderer/function/input'
+import UserInfoPanComponent, { UserInfoPan } from '@renderer/components/UserInfoPan.vue'
 
+type IUser = any
 
+const userInfoPanData = shallowReactive<{
+    user: undefined | IUser | number,
+    x: number,
+    y: number,
+}>({
+    user: undefined,
+    x: 0,
+    y: 0,
+})
+const userInfoPanFunc: UserInfoPan = {
+    open: (user: IUser | number, x: number, y: number) => {
+        userInfoPanData.user = user
+        userInfoPanData.x = x
+        userInfoPanData.y = y
+    },
+    close: () => {
+        userInfoPanData.user = undefined
+    },
+}
+</script>
+
+<script lang="ts">
     export default defineComponent({
         name: 'ViewChat',
-        components: { Info, MsgBody, NoticeBody, FacePan, MergePan },
-        props: ['chat', 'list', 'mumberInfo', 'imgView'],
+        props: ['chat', 'list', 'imgView'],
         data() {
             return {
                 uuid,
@@ -1564,17 +1563,6 @@ import { wheelMask } from '@renderer/function/input'
                     }
                     runtimeData.popBoxList.push(popInfo)
                 }
-            },
-
-            /**
-             * 获取悬浮窗显示位置
-             */
-            getPopPost() {
-                const x =
-                    this.mumberInfo.x === undefined ? '0' : this.mumberInfo.x
-                const y =
-                    this.mumberInfo.y === undefined ? '0' : this.mumberInfo.y
-                return 'margin-left:' + x + 'px;margin-top:' + y + 'px;'
             },
 
             /**


### PR DESCRIPTION
<img width="547" height="294" alt="图片" src="https://github.com/user-attachments/assets/0404c19b-d660-41f5-ba0d-107893696d9e" />

## Sourcery 總結

將舊有嘅內聯 @user 資訊彈出框，替換成全新嘅 UserInfoPan 組件。呢個組件會喺鼠標懸停喺頭像或提及時觸發，並具有延遲同動畫效果，同時處理越界定位問題；重構腳本為 `<script setup>` 格式，移除舊有代碼，並更新相關樣式。

新功能:
- 引入一個可重用嘅 UserInfoPan 組件，用於喺鼠標懸停喺頭像或 @提及時，以 0.5 秒延遲同進出動畫顯示群組成員資訊

改進:
- 重構 Chat.vue 同 MsgBody.vue，使用統一嘅懸停檢測鉤子，並傳遞 userInfoPan 處理器，取代原有嘅內聯代碼
- 更新成員資訊面板嘅樣式同動畫，增加邊界檢測以確保面板顯示喺螢幕內，並為角色添加用戶稱謂徽章

雜項:
- 喺 OptDev.vue 中公開一個新嘅開發標誌

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the old inline @user info popup with a new UserInfoPan component that is triggered on hover over avatars or mentions, uses a delay and animation, and handles out-of-bounds positioning; refactor scripts to <script setup>, remove legacy code, and update related styles.

New Features:
- Introduce a reusable UserInfoPan component to display group member info on hover over avatars or @mentions with a 0.5s delay and entry/exit animations

Enhancements:
- Refactor Chat.vue and MsgBody.vue to use a unified hover detection hook and pass a userInfoPan handler instead of inline code
- Update member-info panel styles and animations, add boundary detection to keep the panel onscreen, and add user-title badges for roles

Chores:
- Expose a new dev flag in OptDev.vue

</details>