### PR TITLE
修了两处bug

### DIFF
--- a/src/renderer/src/components/MsgBody.vue
+++ b/src/renderer/src/components/MsgBody.vue
@@ -569,7 +569,7 @@ function getUserById(id: number): IUser | undefined {
              * @param id 消息 id
              */
             scrollToMsg(id: string) {
-                emit('scrollToMsg', 'chat-' + id)
+                this.$emit('scrollToMsg', 'chat-' + id)
             },
 
             /**
@@ -635,7 +635,7 @@ function getUserById(id: number): IUser | undefined {
                 if (imgHeight > vh * 0.35)
                     imgWidth = (imgWidth * (vh * 0.35)) / imgHeight
                 img.style.setProperty('--width', `${imgWidth}px`)
-                emit('imageLoaded', img.offsetHeight)
+                this.$emit('imageLoaded', img.offsetHeight)
             },
 
             /**
@@ -960,7 +960,7 @@ function getUserById(id: number): IUser | undefined {
 
             sendPoke() {
                 // 调用上级组件的 poke 方法
-                emit('sendPoke', this.data.sender.user_id)
+                this.$emit('sendPoke', this.data.sender.user_id)
             },
 
             async showPock() {

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -317,11 +317,13 @@
             </div>
             <!-- 消息发送框 -->
             <div>
-                <div @click="moreFunClick(runtimeData.sysConfig.quick_send)" @contextmenu="moreFunClick()">
-                    <font-awesome-icon v-if="runtimeData.sysConfig.quick_send == 'default'" :icon="['fas', 'plus']" />
-                    <font-awesome-icon v-if="runtimeData.sysConfig.quick_send == 'img'" :icon="['fas', 'image']" />
-                    <font-awesome-icon v-if="runtimeData.sysConfig.quick_send == 'file'" :icon="['fas', 'folder']" />
-                    <font-awesome-icon v-if="runtimeData.sysConfig.quick_send == 'face'" :icon="['fas', 'face-laugh']" />
+                <div @click="moreFunClick(runtimeData.sysConfig.quick_send)"
+                v-menu.prevent="_=>moreFunClick()">
+                    <font-awesome-icon v-if="tags.showMoreDetail || details.find(item => item.open)" :icon="['fas', 'minus']" />
+                    <font-awesome-icon v-else-if="runtimeData.sysConfig.quick_send == 'default'" :icon="['fas', 'plus']" />
+                    <font-awesome-icon v-else-if="runtimeData.sysConfig.quick_send == 'img'" :icon="['fas', 'image']" />
+                    <font-awesome-icon v-else-if="runtimeData.sysConfig.quick_send == 'file'" :icon="['fas', 'folder']" />
+                    <font-awesome-icon v-else-if="runtimeData.sysConfig.quick_send == 'face'" :icon="['fas', 'face-laugh']" />
                 </div>
                 <div>
                     <form @submit="mainSubmit">
@@ -568,6 +570,7 @@ import {
 import { wheelMask } from '@renderer/function/input'
 import UserInfoPanComponent, { UserInfoPan } from '@renderer/components/UserInfoPan.vue'
 import { backend } from '@renderer/runtime/backend'
+import { vMenu } from '@renderer/function/utils/appUtil'
 
 type IUser = any
 
@@ -2244,18 +2247,20 @@ const userInfoPanFunc: UserInfoPan = {
                     item.open = false
                 })
                 // 如果有关闭操作，就不打开更多功能菜单
-                if(!hasOpen) {
-                    if (type == 'default') {
-                        this.tags.showMoreDetail = !this.tags.showMoreDetail
-                    } else {
-                        this.tags.showMoreDetail = false
-                        // 打开指定的更多功能菜单
-                        switch(type) {
-                            case 'img': this.runSelectImg(); break
-                            case 'file': this.runSelectFile(); break
-                            case 'face': this.details[1].open = !this.details[1].open; break
-                        }
-                    }
+                if (hasOpen) return
+
+                // 如果更多功能菜单已经打开，则关闭
+                if (this.tags.showMoreDetail) {
+                    this.tags.showMoreDetail = false
+                    return
+                }
+
+                // 打开指定的更多功能菜单
+                switch(type) {
+                    case 'default': this.tags.showMoreDetail = true; break
+                    case 'img': this.runSelectImg(); break
+                    case 'file': this.runSelectFile(); break
+                    case 'face': this.details[1].open = !this.details[1].open; break
                 }
             },
 


### PR DESCRIPTION
一处是Chat更多操作右键会触发浏览器菜单，同时还加了个关闭图标
另一处是我改MsgBody时，在script里使用script setup定义的emit，未找到定义

## Sourcery 總結

修復聊天「更多操作」菜單右鍵行為，並修正 MsgBody 中未定義的 emit 調用。

錯誤修復：
- 防止瀏覽器上下文菜單出現在聊天「更多」按鈕上，添加關閉圖標，並優化菜單切換邏輯
- 在 MsgBody 中，將 scrollToMsg、imageLoaded 和 sendPoke 事件的未定義 emit 調用替換為 this.$emit

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix chat 'more operations' menu right-click behavior and correct undefined emit calls in MsgBody.

Bug Fixes:
- Prevent the browser context menu from appearing on the chat 'more' button, add a close icon, and refine the menu toggle logic
- Replace undefined emit calls with this.$emit for scrollToMsg, imageLoaded, and sendPoke events in MsgBody

</details>