### PR TITLE
fix: v-menu 在触屏时影响click

### DIFF
--- a/src/renderer/src/function/utils/appUtil.ts
+++ b/src/renderer/src/function/utils/appUtil.ts
@@ -1292,6 +1292,9 @@ function createVMenu(): Directive<HTMLElement, (event: MenuEventData)=>void> {
             const controller = new AbortController()
             const options = {signal: controller.signal}
 
+            // 修复由于 touch 阻断 click 事件冒泡的问题
+            let touchStartTime = 0
+
             // 添加监听
             el.addEventListener('contextmenu', (event) => {
                 if (prevent) event.preventDefault()
@@ -1307,6 +1310,7 @@ function createVMenu(): Directive<HTMLElement, (event: MenuEventData)=>void> {
                 if (prevent) event.preventDefault()
                 if (stop) event.stopPropagation()
                 menuTouchHandle(event, binding)
+                touchStartTime = Date.now()
             }, options)
             el.addEventListener('touchmove', (event) => {
                 if (prevent) event.preventDefault()
@@ -1317,6 +1321,9 @@ function createVMenu(): Directive<HTMLElement, (event: MenuEventData)=>void> {
                 if (prevent) event.preventDefault()
                 if (stop) event.stopPropagation()
                 menuTouchEnd(event)
+				// 快速点击则触发点击事件
+                if (Date.now() - touchStartTime < 200)
+					event.target?.['click']?.()
             }, options)
 
             // 绑定控制器


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修正觸摸事件阻擋 v-menu 點擊事件的問題：透過追蹤觸摸開始時間，並在快速點擊時手動觸發點擊事件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent touch events from blocking click events in v-menu by tracking touch start time and manually firing click on quick taps

</details>