### PR TITLE
平铺式桌面适配

### DIFF
--- a/src/electron/function/ipc.ts
+++ b/src/electron/function/ipc.ts
@@ -132,6 +132,29 @@ export function regIpcListener() {
             win.setPosition(point.x, point.y)
         }
     })
+    // 判断是否为平铺窗口管理器
+    ipcMain.handle('win:isTiling', () => {
+        const TILING_WMS = [
+            'i3',
+            'sway',
+            'bspwm',
+            'awesome',
+            'herbstluftwm',
+            'hyprland'
+        ]
+
+        // 仅在 Linux 下尝试读取环境变量
+        if (process.platform === 'linux') {
+            const wm =
+                process.env.XDG_CURRENT_DESKTOP?.toLowerCase() ||
+                process.env.DESKTOP_SESSION?.toLowerCase() ||
+                process.env.GDMSESSION?.toLowerCase() ||
+                ''
+            return TILING_WMS.includes(wm)
+        } else {
+            return false
+        }
+    })
     // 保存信息
     ipcMain.on('opt:store', (_, arg) => {
         store.set(arg.key, arg.value)

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -5,7 +5,7 @@
         {{ ' / client: ' + appClient.type }}
         {{ ' / fps: ' + fps.value }}
     </div>
-    <div v-if="['linux', 'win32'].includes(backend.platform ?? '')"
+    <div v-if="needBar()"
         :class="'top-bar' + ((backend.platform == 'win32' && dev) ? ' win' : '')"
         name="appbar"
         data-tauri-drag-region="true">
@@ -225,7 +225,7 @@ import { runtimeData } from '@renderer/function/msg'
 import { BaseChatInfoElem } from '@renderer/function/elements/information'
 import { Notify } from './function/notify'
 import { updateBaseOnMsgList } from './function/utils/msgUtil'
-import { getDeviceType } from './function/utils/systemUtil'
+import { getDeviceType, needBar } from './function/utils/systemUtil'
 import { uptime } from '@renderer/main'
 
 import Options from '@renderer/pages/Options.vue'
@@ -247,6 +247,7 @@ export default defineComponent({
     data() {
         return {
             backend,
+            needBar,
             appClient: backend,
             dev: import.meta.env.DEV,
             sse: import.meta.env.VITE_APP_SSE_MODE == 'true',
@@ -338,9 +339,13 @@ export default defineComponent({
                 'merge_forward_width_type',
                 Option.get('merge_forward_width_type'),
             )
-            if (['linux', 'win32'].includes(backend.platform ?? '')) {
+            if (needBar()) {
                 const app = document.getElementById('base-app')
                 if (app) app.classList.add('withBar')
+            }
+            if (backend.isTiling) {
+                const dom = document.getElementById('app')
+                if (dom) dom.classList.add('tiling')
             }
             // 基础初始化完成
             logger.system('欢迎回来，开发者。Stapxs QQ Lite 正处于 ' + (this.dev ? 'development' : 'production') + ' 模式。正在为您加载更多功能。')

--- a/src/renderer/src/assets/css/append/append_linux.css
+++ b/src/renderer/src/assets/css/append/append_linux.css
@@ -7,6 +7,15 @@
     height: calc(100% - 20px);
     border: 1px solid #00000059;
 }
+#app.tiling {
+    margin: 0;
+    border-radius: 0;
+    overflow: hidden;
+    box-shadow: unset;
+    width: 100%;
+    height: 100%;
+    border: unset;
+}
 #base-app.withBar {
     padding-top: 0;
     height: 100%;

--- a/src/renderer/src/assets/css/append/append_linux.css
+++ b/src/renderer/src/assets/css/append/append_linux.css
@@ -87,15 +87,23 @@
     padding-top: 25px;
     height: calc(100% - 25px);
 }
+#app.tiling .opt-main > div:last-child {
+    padding-top: 15px;
+    height: calc(100% - 15px);
+}
 .pop-box > div:last-child {
     height: calc(100% - 20px);
     width: calc(100% - 20px);
     border-radius: 7px;
     margin: 10px;
 }
-
 .opt-main > div:first-child {
     margin-top: 20px;
+    margin-bottom: 20px;
+}
+#app.tiling .opt-main > div:first-child {
+    margin-top: 10px;
+    overflow-y: scroll;
 }
 
 @media (max-width: 700px) {

--- a/src/renderer/src/function/utils/systemUtil.ts
+++ b/src/renderer/src/function/utils/systemUtil.ts
@@ -423,3 +423,12 @@ export async function getApi(url: string) {
         }
     }
 }
+
+export function needBar(): boolean {
+    if (backend.platform === 'win32')
+        return true
+    if (backend.platform === 'linux' && !backend.isTiling)
+        return true
+
+    return false
+}

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -10,10 +10,12 @@
 -->
 
 <template>
-    <div id="chat-pan"
-        :class="'chat-pan' +
-            (runtimeData.tags.openSideBar ? ' open' : '') +
-            (['linux', 'win32'].includes(backend.platform ?? '') ? ' withBar' : '')"
+    <div ref="chat-pan"
+        :class="{
+            'chat-pan': true,
+            'open': runtimeData.tags.openSideBar,
+            'withBar': needBar()
+        }"
         :style="`background-image: url(${runtimeData.sysConfig.chat_background});`"
         @touchstart="chatMoveStartEvent"
         @touchmove="chatMoveEvent"
@@ -545,6 +547,7 @@ import {
     getTimeConfig,
     getTrueLang,
     getViewTime,
+    needBar,
 } from '@renderer/function/utils/systemUtil'
 import {
     getMsgRawTxt,

--- a/src/renderer/src/pages/chat-view/Chat弹幕.vue
+++ b/src/renderer/src/pages/chat-view/Chat弹幕.vue
@@ -10,11 +10,11 @@
 <template>
     <div
         id="chat-pan"
-        :class="
-            'chat-pan' +
-                (runtimeData.tags.openSideBar ? ' open' : '') +
-                (['linux', 'win32'].includes(backend.platform ?? '') ? ' withBar' : '')
-        ">
+        :class="{
+            'chat-pan': true,
+            'open': runtimeData.tags.openSideBar,
+            'withBar': needBar()
+        }">
         <div class="danmu-pan">
             <vue-danmaku
                 ref="danmakuRef"
@@ -337,7 +337,7 @@
         SQCodeElem,
     } from '@renderer/function/elements/information'
     import { PopInfo, PopType } from '@renderer/function/base'
-    import { getTrueLang } from '@renderer/function/utils/systemUtil'
+    import { getTrueLang, needBar } from '@renderer/function/utils/systemUtil'
     import { backend } from '@renderer/runtime/backend'
 
     export default defineComponent({
@@ -346,6 +346,7 @@
         props: ['chat', 'list', 'mumberInfo'],
         data() {
             return {
+                needBar,
                 backend,
                 opt: {
                     speeds: 140,

--- a/src/renderer/src/pages/chat-view/Chat终端.vue
+++ b/src/renderer/src/pages/chat-view/Chat终端.vue
@@ -15,11 +15,11 @@
 <template>
     <div
         id="chat-pan"
-        :class="
-            'chat-pan' +
-                (runtimeData.tags.openSideBar ? ' open' : '') +
-                (['linux', 'win32'].includes(backend.platform ?? '') ? ' withBar' : '')
-        ">
+        :class="{
+            'chat-pan': true,
+            'open': runtimeData.tags.openSideBar,
+            'withBar': needBar()
+        }">
         <div
             id="shell-pan"
             class="shell-pan">
@@ -164,7 +164,6 @@
 </template>
 
 <script lang="ts">
-    import app from '@renderer/main'
     import SendUtil from '@renderer/function/sender'
     import packageInfo from '../../../../../package.json'
     import Option from '@renderer/function/option'
@@ -173,7 +172,7 @@
     import { Connector } from '@renderer/function/connect'
     import { defineComponent, markRaw } from 'vue'
     import { runtimeData } from '@renderer/function/msg'
-    import { getTrueLang } from '@renderer/function/utils/systemUtil'
+    import { getTrueLang, needBar } from '@renderer/function/utils/systemUtil'
     import {
         MsgItemElem,
         SQCodeElem,
@@ -197,6 +196,7 @@
         data() {
             return {
                 backend,
+                needBar,
                 tags: {
                     fullscreen: false,
                     fistget: true,

--- a/src/renderer/src/pages/chat-view/SystemNotice.vue
+++ b/src/renderer/src/pages/chat-view/SystemNotice.vue
@@ -8,9 +8,12 @@
 
 <template>
     <div id="chat-pan"
-        :class=" 'chat-pan sys-not-pan' +
-            (runtimeData.tags.openSideBar ? ' open' : '') +
-            (['linux', 'win32'].includes(backend.platform ?? '') ? ' withBar' : '')">
+        :class="{
+            'chat-pan': true,
+            'sys-not-pan': true,
+            'open': runtimeData.tags.openSideBar,
+            'withBar': needBar()
+        }">
         <div>
             <font-awesome-icon :icon="['fas', 'angle-left']" @click="exit" />
             <span>{{ $t('系统消息') }}</span>
@@ -96,7 +99,7 @@
 
     import { runtimeData } from '@renderer/function/msg'
     import { Connector } from '@renderer/function/connect'
-    import { getTrueLang } from '@renderer/function/utils/systemUtil'
+    import { getTrueLang, needBar } from '@renderer/function/utils/systemUtil'
     import { backend } from '@renderer/runtime/backend'
 
     export default defineComponent({
@@ -105,6 +108,7 @@
         data() {
             return {
                 backend,
+                needBar,
                 trueLang: getTrueLang(),
                 runtimeData: runtimeData,
                 dev: import.meta.env.DEV,

--- a/src/renderer/src/runtime/backend.ts
+++ b/src/renderer/src/runtime/backend.ts
@@ -15,6 +15,7 @@ export const backend = {
     platform: undefined as 'win32' | 'darwin' | 'linux' | 'android' | 'ios' | 'web' | undefined,
     release: '',
     proxy: undefined as number | undefined,
+    isTiling: false,
 
     function: undefined as IpcRenderer |
     {
@@ -51,10 +52,8 @@ export const backend = {
 
     /**
      * 初始化后端功能
-     *
-     * @returns {Promise<void>}
      */
-    async init() {
+    async init(): Promise<void> {
         const { $t } = app.config.globalProperties
         if (window.electron != undefined) {
             this.type = 'electron';
@@ -84,6 +83,10 @@ export const backend = {
         this.platform = await this.call(undefined, 'sys:getPlatform', true)
         this.release = await this.call(undefined, 'sys:getRelease', true)
         this.proxy  = await this.call(undefined, 'sys:runProxy', true)
+        if (this.platform == 'linux') {
+            this.isTiling = await this.call(undefined, 'win:isTiling', true)
+            console.log('是否为平铺窗口管理器：', this.isTiling)
+        }
         if(this.type == 'tauri' && !this.proxy) {
             logger.error(null, 'Tauri 代理服务似乎没有正常启动，此服务异常将会影响应用内的大部分外部资源的加载。')
             popInfo.add(PopType.ERR, $t('Tauri 代理服务似乎没有正常启动'), false)

--- a/src/tauri/src/commands/win.rs
+++ b/src/tauri/src/commands/win.rs
@@ -65,3 +65,30 @@ pub fn win_open_dev_tools(app: tauri::AppHandle) {
 pub fn win_set_title(window: tauri::Window, data: String) {
     window.set_title(&data).unwrap();
 }
+
+
+#[command]
+pub fn win_is_tiling() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        const TILING_WMS: [&str; 6] = [
+            "i3",
+            "sway",
+            "bspwm",
+            "awesome",
+            "herbstluftwm",
+            "hyprland"
+        ];
+        use std::env;
+        let wm = env::var("XDG_CURRENT_DESKTOP")
+            .or_else(|_| env::var("DESKTOP_SESSION"))
+            .or_else(|_| env::var("GDMSESSION"))
+            .unwrap_or_default()
+            .to_lowercase();
+        return TILING_WMS.contains(&wm.as_str());
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        return false;
+    }
+}

--- a/src/tauri/src/lib.rs
+++ b/src/tauri/src/lib.rs
@@ -213,6 +213,7 @@ pub fn run() {
             commands::win::win_move,
             commands::win::win_open_dev_tools,
             commands::win::win_set_title,
+            commands::win::win_is_tiling,
             commands::opt::opt_get_system_info,
             commands::opt::opt_store,
             commands::opt::opt_save_all,


### PR DESCRIPTION
修复 #248 
<img width="1920" height="1080" alt="图片" src="https://github.com/user-attachments/assets/5cf76a38-60a7-4a83-a17e-24fd7e8648f1" />
其实我只用过hyprland，其他的啥表现不清楚，wm 名字都是 ai 给的

其实还有个疑问...为啥linux设置的大小这么小？现在大电脑27寸1080p显示器看着还能接受，平板十来寸2k屏，ui真是小的不能用...还不如不带append_linux.css的web版看的清晰

## Sourcery 總結

喺 Linux 上偵測平鋪式視窗管理器，並相應調整使用者介面佈局，透過顯示或隱藏頂部欄以及喺平鋪環境中應用全螢幕樣式。

新功能：
- 喺 Tauri 同 Electron 中新增 `win:isTiling` 指令，透過環境變數偵測平鋪式視窗管理器 (WMs)
- 引入 `needBar()` 工具，以判斷何時渲染標題欄，根據平台同平鋪狀態
- 公開 `backend.isTiling` 標誌，並喺運行時應用一個「tiling」CSS 類別嚟調整視窗邊框

錯誤修復：
- 解決 Linux 上嘅平鋪式視窗管理器下嘅佈局問題 (#248)

改進：
- 重構 Vue 組件，使用 `needBar()` 嚟條件式渲染頂部欄以及聊天容器樣式
- 為 Linux 上嘅 `.tiling` 狀態新增 CSS 規則，以移除邊框、陰影同邊距

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Detect tiling window managers on Linux and adapt the UI layout accordingly by showing or hiding the top bar and applying full-screen styling in tiling environments.

New Features:
- Add win:isTiling command in both Tauri and Electron to detect tiling WMs via environment variables
- Introduce needBar() utility to determine when to render the title bar based on platform and tiling status
- Expose backend.isTiling flag and apply a “tiling” CSS class at runtime to adjust window chrome

Bug Fixes:
- Resolve layout issues under tiling window managers on Linux (#248)

Enhancements:
- Refactor Vue components to use needBar() for conditional rendering of the top bar and chat container styling
- Add CSS rules for `.tiling` state on Linux to remove borders, shadows, and margins

</details>