### PR TITLE
fix: 非正方形头像被拉伸

### DIFF
--- a/src/renderer/src/assets/css/chat.css
+++ b/src/renderer/src/assets/css/chat.css
@@ -71,6 +71,7 @@ input {
     border: 2px solid var(--color-card-2);
     border-radius: 7px;
     margin-right: 10px;
+    object-fit: cover;
     height: 50px;
     width: 50px;
 }
@@ -1695,6 +1696,7 @@ div.tiny-session-body > img {
     margin-right: 10px;
     height: 2.5rem;
     width: 2.5rem;
+    object-fit: cover;
 }
 div.tiny-session-body > svg {
     border-radius: 7px;

--- a/src/renderer/src/assets/css/view.css
+++ b/src/renderer/src/assets/css/view.css
@@ -565,6 +565,7 @@ textarea:focus {
     border-radius: 7px;
     height: 50px;
     width: 50px;
+    object-fit: cover;
 }
 .friend-body > svg {
     transition:


### PR DESCRIPTION
<img width="54" height="54" alt="Screen Shot 2025-09-17 at 22 22 48" src="https://github.com/user-attachments/assets/370e0b37-3263-4a41-a8d4-1ffb4a66a3f4" />
<img width="54" height="54" alt="Screen Shot 2025-09-17 at 22 25 19" src="https://github.com/user-attachments/assets/a71a14a4-9bb8-4e22-8377-d310420f4d14" />

emm,这样开多个pr是不是有点不太优雅？

## Sourcery 總結

錯誤修正：
- 透過應用 `object-fit: cover` 到相關選擇器，防止非正方形頭像圖片被拉伸

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent non-square avatar images from being stretched by applying object-fit: cover to relevant selectors

</details>