### PR TITLE
fix: 背景图片的一些问题

### DIFF
--- a/src/renderer/src/assets/css/chat.css
+++ b/src/renderer/src/assets/css/chat.css
@@ -9,7 +9,7 @@ input {
     background-color: var(--color-card);
     background-repeat: no-repeat;
     background-position: center;
-    background-size: auto 100%;
+    background-size: cover;
 
     color: var(--color-font);
     flex-direction: column;

--- a/src/renderer/src/assets/css/options.css
+++ b/src/renderer/src/assets/css/options.css
@@ -416,6 +416,36 @@
     opacity: 0;
 }
 
+
+.opt-item > div.file-choice {
+    display: flex;
+    max-width: 170px;
+    flex-direction: row;
+    margin-right: 0;
+}
+
+.opt-item > div.file-choice > div {
+    background: var(--color-card-1);
+    border-radius: 7px;
+    font-size: 0.8rem;
+    height: 30px;
+    min-width: 30px;
+    line-height: 30px;
+    text-align: center;
+}
+
+.opt-item > div.file-choice > div.choice-btn {
+    flex: 1;
+    padding: 0 10px;
+}
+
+.opt-item > div.file-choice > div.rm-btn {
+    margin-left: 10px;
+    width: 30px;
+    cursor: pointer;
+    color: var(--color-red);
+}
+
 .l10n-info {
     border-left: 7px solid var(--color-main);
     background: var(--color-card-1);

--- a/src/renderer/src/pages/options/OptView.vue
+++ b/src/renderer/src/pages/options/OptView.vue
@@ -146,9 +146,27 @@
                     <span>{{ $t('背景图片') }}</span>
                     <span>{{ $t('嘿嘿嘿（痴呆') }}</span>
                 </div>
-                <input v-model="runtimeData.sysConfig.chat_background"
-                    class="ss-input" style="width: 150px"
-                    type="text" name="chat_background" @keyup="save">
+                <div class="file-choice">
+                    <div class="choice-btn"
+                        @click="($refs.choiceImg as any)?.click()">
+                        {{
+                            runtimeData.sysConfig.chat_background
+                                ? $t('更换背景')
+                                : $t('上传背景')
+                        }}
+                        <input ref="choiceImg"
+                            type="file"
+                            style="display: none"
+                            name="chat_background"
+                            accept="image/*"
+                            @change="setBackground($event)">
+                    </div>
+                    <div v-if="runtimeData.sysConfig.chat_background !== ''"
+                        class="rm-btn"
+                        @click="removeBackground">
+                        <font-awesome-icon :icon="['fas', 'xmark']" />
+                    </div>
+                </div>
             </div>
             <div class="opt-item">
                 <div :class="checkDefault('chat_background_blur')" />
@@ -338,7 +356,7 @@
 <script lang="ts">
     import { defineComponent, toRaw } from 'vue'
     import { runtimeData } from '../../function/msg'
-    import { runASWEvent as save, get, checkDefault } from '../../function/option'
+    import Option, { runASWEvent as save, get, checkDefault } from '../../function/option'
     import { BrowserInfo, detect } from 'detect-browser'
     import { getDeviceType } from '@renderer/function/utils/systemUtil'
 
@@ -506,6 +524,32 @@
             changeIcon(name: string) {
                 backend.call('Onebot', 'changeIcon', false, { name: name != '' ? (name + 'AppIcon') : name })
                 this.usedIcon = name
+            },
+
+
+            /**
+             * 设置背景图片
+             */
+            setBackground(event: Event) {
+                const sender = event.target as HTMLInputElement
+                const img = sender.files?.[0]
+                if (!img) return
+                img.arrayBuffer().then((buffer) => {
+                    const base64String = btoa(
+                        new Uint8Array(buffer)
+                            .reduce((data, byte) => data + String.fromCharCode(byte), ''),
+                    )
+                    const imgSrc = `data:${img.type};base64,${base64String}`
+                    runtimeData.sysConfig.chat_background = imgSrc
+                    Option.runAS('chat_background', imgSrc)
+                })
+            },
+            /**
+             * 移除背景图片
+             */
+            removeBackground() {
+                runtimeData.sysConfig.chat_background = ''
+                Option.runAS('chat_background', '')
             },
         },
     })


### PR DESCRIPTION
记得url在chrome上不能用，改成让用户手动上传转dataurl了

## Sourcery 摘要

將背景圖片嘅 URL 輸入框替換成檔案上載控件，讓用戶可以將圖片以 data URL 形式上載並移除。

新功能：
- 新增檔案上載使用者介面，用於設定聊天背景圖片
- 將上載嘅圖片轉換成 base64 data URL，並儲存到配置中
- 提供一個移除按鈕，用於清除聊天背景圖片

優化：
- 更新 CSS 以設定檔案上載同移除按鈕嘅樣式
- 將 background-size 更改為 cover，用於聊天背景顯示

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace background image URL input with file upload controls, enabling users to upload images as data URLs and remove them

New Features:
- Add file upload UI for setting chat background images
- Convert uploaded images to base64 data URLs and persist them in configuration
- Provide a removal button to clear the chat background image

Enhancements:
- Update CSS to style the file upload and remove buttons
- Change background-size to cover for chat background display

</details>