### PR TITLE
feat: 复制图片

### DIFF
--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1406,3 +1406,18 @@ msgstr ""
 
 msgid "复制图片"
 msgstr ""
+
+msgid "赞助者"
+msgstr ""
+
+msgid "增强透明"
+msgstr ""
+
+msgid "超级加倍！"
+msgstr ""
+
+msgid "网易云音乐预览信息服务"
+msgstr ""
+
+msgid "Bilibili 预览信息服务"
+msgstr ""

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1403,3 +1403,6 @@ msgstr ""
 
 msgid "切换语言"
 msgstr ""
+
+msgid "复制图片"
+msgstr ""

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -410,6 +410,10 @@
                         <div><font-awesome-icon :icon="['fas', 'code']" /></div>
                         <a>{{ $t('复制选中文本') }}</a>
                     </div>
+                    <div v-show="tags.menuDisplay.copyImg" @click="copyImg">
+                        <div><font-awesome-icon :icon="['fas', 'object-ungroup']" /></div>
+                        <a>{{ $t('复制图片') }}</a>
+                    </div>
                     <div v-show="tags.menuDisplay.downloadImg != false" @click="downloadImg">
                         <div><font-awesome-icon :icon="['fas', 'floppy-disk']" /></div>
                         <a>{{ $t('下载图片') }}</a>
@@ -553,6 +557,7 @@ import {
 	VMoveOptions,
 } from '@renderer/function/utils/appUtil'
 import {
+    copyToClipboard,
     getTimeConfig,
     getTrueLang,
     getViewTime,
@@ -697,6 +702,7 @@ const userInfoPanFunc: UserInfoPan = {
                         select: true,
                         copy: true,
                         copySelect: false,
+                        copyImg: false,
                         downloadImg: false as string | false,
                         revoke: false,
                         at: true,
@@ -1170,11 +1176,13 @@ const userInfoPanFunc: UserInfoPan = {
                                 this.tags.menuDisplay.add = false
                             }
                         })
-                        if (select.nodeName == 'IMG') {
+                        if (select.nodeName == 'IMG' && (select as HTMLImageElement).src.length > 0) {
                             // 右击图片需要显示的内容，这边特例设置为链接
                             this.tags.menuDisplay.downloadImg = (
                                 select as HTMLImageElement
                             ).src
+                            if (!backend.isWeb())
+                                this.tags.menuDisplay.copyImg = true
                         }
                     }
                     // 鼠标位置
@@ -1224,6 +1232,7 @@ const userInfoPanFunc: UserInfoPan = {
                     copy: true,
                     copySelect: false,
                     downloadImg: false,
+                    copyImg: false,
                     revoke: false,
                     at: false,
                     poke: false,
@@ -1539,6 +1548,61 @@ const userInfoPanFunc: UserInfoPan = {
                         )
                 }
                 this.closeMsgMenu()
+            },
+
+            /**
+             * 复制图片
+             */
+            async copyImg() {
+                if (!this.tags.menuDisplay.downloadImg) return
+
+                // 关闭菜单
+                this.closeMsgMenu()
+
+                // 类型白名单
+                const typeWhiteList = [
+                    'image/png',
+                    'image/gif',
+                    'image/webp',
+                    'image/svg+xml',
+                ]
+
+                // 获取图片数据
+                const response = await fetch(this.tags.menuDisplay.downloadImg)
+                let blob = await response.blob()
+
+                // 乱七八糟浏览器不一定支持的格式统统转png
+                if (!typeWhiteList.includes(blob.type)) {
+                    // 创建 canvas 来转换格式
+                    const img = new Image()
+                    const canvas = document.createElement('canvas')
+                    const ctx = canvas.getContext('2d')
+
+                    await new Promise((resolve, reject) => {
+                        img.onload = resolve
+                        img.onerror = reject
+                        img.src = URL.createObjectURL(blob)
+                    })
+
+                    canvas.width = img.width
+                    canvas.height = img.height
+                    ctx?.drawImage(img, 0, 0)
+
+                    // 转换为 PNG blob
+                    blob = await new Promise(resolve => {
+                        canvas.toBlob((blob)=>{
+                            resolve(blob as Blob)
+                        }, 'image/png')
+                    })
+
+                    URL.revokeObjectURL(img.src)
+                }
+                const item = new ClipboardItem({ [blob.type]: blob })
+                try {
+                    await copyToClipboard([item])
+                    const popInfo = new PopInfo()
+                    popInfo.add(PopType.INFO, this.$t('复制成功'))
+                }catch {/**/}
             },
 
             /**

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -1562,8 +1562,6 @@ const userInfoPanFunc: UserInfoPan = {
                 // 类型白名单
                 const typeWhiteList = [
                     'image/png',
-                    'image/gif',
-                    'image/webp',
                     'image/svg+xml',
                 ]
 


### PR DESCRIPTION
#287 
仅限有跨域条件的情况下才可以使用
浏览器竟然不能复制gif（恼。动图只能强制转静态图复制了...

## Sourcery 摘要

透過新增一個「複製圖片」右鍵選單選項，並實作 copyImg 處理器來擷取、轉換並將圖片資料複製到剪貼簿，從而啟用從聊天訊息複製圖片的功能。

新功能：
- 在非網頁環境中，當右鍵點擊圖片時，在聊天右鍵選單中顯示「複製圖片」選項
- 實作 copyImg 方法來擷取圖片 blob，將不支援的格式轉換為 PNG，並使用 Clipboard API 複製它們

文件：
- 為「复制图片」選單項目新增中文本地化條目

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable copying images from chat messages by adding a 'Copy Image' context menu option and implementing the copyImg handler that fetches, converts, and copies image data to the clipboard

New Features:
- Show 'Copy Image' option in chat context menu when right-clicking images in non-web environments
- Implement copyImg method to fetch image blobs, convert unsupported formats to PNG, and copy them using the Clipboard API

Documentation:
- Add Chinese localization entry for the '复制图片' menu item

</details>