### PR TITLE
微调了一下zh-tw

### DIFF
--- a/src/renderer/src/assets/l10n/zh-TW.po
+++ b/src/renderer/src/assets/l10n/zh-TW.po
@@ -235,7 +235,7 @@ msgid "开发者选项"
 msgstr "開發人員選項"
 
 msgid "日志等级"
-msgstr "日誌等級"
+msgstr "紀錄等級"
 
 msgid "全部"
 msgstr "全部"
@@ -682,7 +682,7 @@ msgid "取消置顶"
 msgstr "取消釘選"
 
 msgid "删除"
-msgstr "删除"
+msgstr "刪除"
 
 msgid "标记已读"
 msgstr "標示為已讀"


### PR DESCRIPTION
台湾那边给日志叫紀錄或者log吧……应该

## Summary by Sourcery

Enhancements:
- 優化繁體中文翻譯，將日誌條目改為使用「紀錄」或「log」

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refine zh-TW translations to use '紀錄' or 'log' for log entries

</details>