### PR TITLE
fix: 未激活的会话不会在全局搜索栏里显示

### DIFF
--- a/src/renderer/src/components/GlobalSessionSearchBar.vue
+++ b/src/renderer/src/components/GlobalSessionSearchBar.vue
@@ -176,7 +176,11 @@ function init() {
     const mainList: Session[] = []
     for (const session of runtimeData.userList) {
         if (runtimeData.onMsgList.find(
-            s => s.user_id === session.user_id || s.group_id === session.group_id,
+            s => (
+                s.user_id && s.user_id === session.user_id
+            ) || (
+                s.group_id && s.group_id === session.group_id
+            )
         )) continue
         mainList.push(session)
     }


### PR DESCRIPTION
## Sourcery 摘要

錯誤修正:
- 只有當 `user_id` 或 `group_id` 兩者都已定義並匹配時，才跳過會話，防止非活躍會話被錯誤地從全局搜索欄中排除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Only skip sessions when user_id or group_id is both defined and matching, preventing inactive sessions from being erroneously excluded from the global search bar

</details>