### PR TITLE
fix: umami 在狭隘情况下，通知和图表重合问题

### DIFF
--- a/src/renderer/src/components/UmamiInfoPan.vue
+++ b/src/renderer/src/components/UmamiInfoPan.vue
@@ -842,6 +842,7 @@
 }
 
 .pie-pan {
+    position: relative;
     width: 100%;
     height: 100%;
     display: flex;
@@ -853,8 +854,9 @@
     margin-top: -15%;
 }
 .pie-pan > a {
-    display: block;
+    top: 5mm;
     width: 80%;
+    position: absolute;
     text-align: center;
     background: var(--color-card-1);
     padding: 10px;


### PR DESCRIPTION
<img width="1920" height="1080" alt="图片" src="https://github.com/user-attachments/assets/14326dc2-9d33-4d5e-a690-319630877225" />
修了这个bug...顺便水一个pr...
请不要在意为啥一个提交会有三个错别字（x

## Sourcery 摘要

透過調整 UmamiInfoPan 組件嘅位置，解決窄視圖中通知同圖表重疊嘅問題。

錯誤修正：
- 將 `.pie-pan` 容器設置為 `position: relative`，以建立定位上下文
- 將錨點元素絕對定位，並帶有 `top offset`，以避免同圖表重疊

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix overlapping of notifications and charts in narrow view by adjusting the positioning of the UmamiInfoPan component.

Bug Fixes:
- Set .pie-pan container to position: relative to establish a positioning context
- Position the anchor element absolutely with a top offset to avoid overlap with the chart

</details>