### PR TITLE
优化:自动构建Docker镜像并推送至GHCR

### DIFF
--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@cb17bfb94d170dac063a73d4d1d8c6e9276a7dd0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@4d1504c5a9df8bec08ef65c7a59d5fc4b25ab529
 
     - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@2064b455456ba96d99e9abbb305f489bac30bfd5
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
 
     - name: Extract Docker metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@032a4b3bda1b716928481836ac5bfe36e1feaad6
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -43,7 +43,7 @@ jobs:
           type=sha,prefix={{branch}}-
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@9e436ba9f2d7bcd1d038c8e55d039d37896ddc5d
       with:
         context: .
         push: true

--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -1,0 +1,53 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - '**'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/stapxs-qq-lite
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=sha,prefix={{branch}}-
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/dockerfile
+++ b/dockerfile
@@ -1,10 +1,23 @@
-# ssqq quick start nginx dockerfile
-# 请确保项目已经构建完成存在 dist 目录
+# 第一阶段：使用Node.js运行ssqq-web生成dist文件
+FROM node:18-alpine AS ssqq-builder
 
+WORKDIR /app
+
+# 设置淘宝镜像源
+RUN npm config set registry https://registry.npmmirror.com/
+
+# 直接运行ssqq-web，使用timeout确保进程不会无限运行
+RUN timeout 30s npx ssqq-web hostname=127.0.0.1 port=8081 || echo "Process completed or timed out"
+
+# 第二阶段：使用Nginx提供静态文件
 FROM nginx:alpine
 
 RUN rm -rf /usr/share/nginx/html/*
-COPY dist /usr/share/nginx/html
+COPY --from=ssqq-builder /app/dist /usr/share/nginx/html
+
+RUN chown -R nginx:nginx /usr/share/nginx/html && \
+    chmod -R 755 /usr/share/nginx/html && \
+    find /usr/share/nginx/html -type f -exec chmod 644 {} \;
 
 RUN sed -i 's/listen       80;/listen       8080;/' /etc/nginx/conf.d/default.conf
 

--- a/push-to-ghcr.yml
+++ b/push-to-ghcr.yml
@@ -1,0 +1,53 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - '**'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/stapxs-qq-lite
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=sha,prefix={{branch}}-
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
优化:自动构建Docker镜像并推送至GHCR

## Sourcery 总结

实现多阶段 Dockerfile 构建，并配置 GitHub Actions 自动构建 Docker 镜像并推送到 GitHub Container Registry。

改进点：
- 将 Dockerfile 转换为多阶段构建，其中包含一个 Node.js 构建器阶段用于收集 dist 文件，以及一个 Nginx 阶段用于提供静态内容。
- 配置 npm 使用更快的镜像并强制执行构建超时，更新生成文件的权限，并将 Nginx 监听端口更改为 8080。

CI：
- 添加一个工作流，以便在每次推送时构建 Docker 镜像并推送到 GHCR，包括 Buildx 设置、注册表登录、元数据提取和缓存使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement multi-stage Dockerfile build and configure GitHub Actions to automatically build and push Docker images to GitHub Container Registry.

Enhancements:
- Convert Dockerfile to a multi-stage build with a Node.js builder stage collecting dist files and an Nginx stage serving static content.
- Configure npm to use a faster mirror and enforce a build timeout, update permissions on generated files, and change the Nginx listen port to 8080.

CI:
- Add a workflow to build and push Docker images to GHCR on every push, including Buildx setup, registry login, metadata extraction, and cache use.

</details>