### PR TITLE
qface的一些优化

### DIFF
--- a/.env
+++ b/.env
@@ -36,3 +36,6 @@ VITE_APP_SPONSORS_URL=https://www.ifdian.net/a/stapxs               # 赞助链�
 VITE_APP_SPONSORS_DATA_API=https://api.stapxs.cn/ssqq/sponsor       # 赞助者数据 API
 ## GitHub 仓库名称
 VITE_APP_REPO_NAME=Stapxs/Stapxs-QQ-Lite-2.0
+
+# 是否下载表情到本地
+VITE_LOCAL_FACE=true

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -22,13 +22,5 @@ export default defineConfig({
     preload: {
         plugins: [externalizeDepsPlugin()],
     },
-    renderer: {
-        server: viteConfig.default.server,
-        resolve: viteConfig.default.resolve,
-        plugins: viteConfig.default.plugins,
-        build: {
-            ...viteConfig.default.build,
-            outDir: 'out/renderer',
-        }
-    },
+    renderer: viteConfig.configFactory('out/renderer'),
 })

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build:electron": "electron-vite build && electron-builder",
     "build:ios": "vite build && capacitor sync ios && sh ./scripts/build-export-ipa.sh",
     "build:android": "vite build && capacitor sync android && capacitor build android",
-    "build:tauri": "tauri build -c src/tauri/tauri.conf.json"
+    "build:tauri": "tauri build -c src/tauri/tauri.conf.json",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.0",

--- a/src/renderer/src/function/model/emoji.ts
+++ b/src/renderer/src/function/model/emoji.ts
@@ -194,15 +194,30 @@ export default class Emoji {
 
     get value(): string {
         if (this.type === 'apng')
-            return `./img/qqface/${this.id}/apng/${this.id}.png`
+            return this.getNormalUrl(this.id)
         else
             return String.fromCodePoint(this.id)
     }
 
     get superValue(): string | undefined {
         if (!this.hasSuper) return undefined
-        if (this.superSuffix.length === 0) return `./img/qqface/${this.id}/lottie/${this.id}.json`
-        return `./img/qqface/${this.id}/lottie/${this.id}_${this.suffixId}.json`
+        if (this.superSuffix.length === 0) return this.getSuperUrl(this.id)
+        else return this.getSuperUrl(this.id, this.suffixId)
+    }
+
+    private getNormalUrl(id: number): string {
+        if (import.meta.env.VITE_LOCAL_FACE == 'true')
+            return `./img/qface/${id}.png`
+        else
+            return `https://koishi.js.org/QFace/assets/qq_emoji/${id}/apng/${id}.png`
+    }
+
+    private getSuperUrl(id: number, suffix?: number): string {
+        const name = suffix ? `${id}_${suffix}` : `${id}`
+        if (import.meta.env.VITE_LOCAL_FACE == 'true')
+            return `./img/qface/${name}.json`
+        else
+            return `https://koishi.js.org/QFace/assets/qq_emoji/${id}/lottie/${name}.json`
     }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,68 +4,104 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 
 import { resolve } from 'path'
 import { visualizer } from 'rollup-plugin-visualizer'
-import { defineConfig, type PluginOption } from 'vite'
+import { defineConfig, loadEnv, UserConfigFnObject, type PluginOption } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
+import qfaceInfo from './src/renderer/src/assets/img/qq-face/public/assets/qq_emoji/_index.json' with { type: 'json' }
 
-// https://vite.dev/config/
-/** @type {import('vite').UserConfig} */
-export default defineConfig({
-    root: './src/renderer',
-    envDir: '../../',
-    base: process.env.BUILD_ENV == 'github-actions'? '/Stapxs-QQ-Lite-2.0/' : './',
-    server: {
-        port: 8080,
-        proxy: {
-            '/api': {
-                target: 'http://localhost:3000',
-                changeOrigin: true,
-                rewrite: (path) => path.replace(/^\/api/, '')
+export function configFactory(outPath: string): UserConfigFnObject {
+    return ({mode}) => {
+        const env = loadEnv(mode, process.cwd())
+        const useLocalFace = env.VITE_LOCAL_FACE == 'true'
+
+        const plugins: PluginOption[] = [
+            vue(),
+            vueDevTools(),
+            ViteYaml(),
+            VitePWA({ registerType: 'autoUpdate' }),
+            visualizer() as PluginOption,
+        ]
+
+    if (useLocalFace) {
+        const apngList: string[] = []
+        const lottieList: string[] = []
+        for (const info of qfaceInfo) {
+            for (const pathInfo of info.assets) {
+                if (pathInfo.type === 2)
+                    apngList.push(`src/assets/img/qq-face/public/${pathInfo.path}`)
+
+                else if (pathInfo.type === 3)
+                    lottieList.push(`src/assets/img/qq-face/public/${pathInfo.path}`)
             }
         }
-    },
-    plugins: [
-        vue(),
-        vueDevTools(),
-        ViteYaml(),
-        VitePWA({ registerType: 'autoUpdate' }),
-        visualizer() as PluginOption,
-        viteStaticCopy({
-            targets: [
-                {
-                src: 'src/assets/img/qq-face/public/assets/qq_emoji/**/*',
-                dest: 'img/qqface',
-                },
-            ],
-        }),
-    ],
-    resolve: {
-        alias: {
-            '@renderer': resolve(__dirname, 'src/renderer/src'),
-            fs: 'rollup-plugin-node-polyfills/polyfills/empty',
+
+        const targets: any = []
+        for (const src of apngList) {
+            targets.push({
+                src: src,
+                dest: 'img/qface/',
+            })
         }
-    },
-    build: {
-        outDir: resolve(__dirname, 'dist'),
-        emptyOutDir: true,
-        chunkSizeWarningLimit: 1100,
-        rollupOptions: {
-            input: { main: resolve('src/renderer/index.html') },
-            external: [ resolve('src/renderer/src/assets/img/qq-face/docs') ],
-            onwarn: (warning) => {
-                if(warning.code === 'CIRCULAR_DEPENDENCY') return
+        for (const src of lottieList) {
+            targets.push({
+                src: src,
+                dest: 'img/qface/',
+            })
+        }
+
+        plugins.push(viteStaticCopy({
+            targets: targets
+        }))
+    }
+
+        return {
+            root: './src/renderer',
+            envDir: '../../',
+            base: process.env.BUILD_ENV == 'github-actions'? '/Stapxs-QQ-Lite-2.0/' : './',
+            server: {
+                port: 8080,
+                proxy: {
+                    '/api': {
+                        target: 'http://localhost:3000',
+                        changeOrigin: true,
+                        rewrite: (path) => path.replace(/^\/api/, '')
+                    }
+                }
             },
-            output: {
-                chunkFileNames: 'assets/js/[name]-[hash].js',
-                entryFileNames: 'assets/js/[name]-[hash].js',
-                assetFileNames: 'assets/[ext]/[name]-[hash].[ext]',
-                manualChunks(id) {
-                    if (id.includes('node_modules')) {
-                        // 让每个插件都打包成独立的文件
-                        return id.toString().split('node_modules/')[1].split('/')[0].toString()
+            plugins: plugins,
+            resolve: {
+                alias: {
+                    '@renderer': resolve(__dirname, 'src/renderer/src'),
+                    fs: 'rollup-plugin-node-polyfills/polyfills/empty',
+                }
+            },
+            build: {
+                outDir: outPath,
+                emptyOutDir: true,
+                chunkSizeWarningLimit: 1100,
+                rollupOptions: {
+                    input: { main: resolve('src/renderer/index.html') },
+                    external: [ resolve('src/renderer/src/assets/img/qq-face/docs') ],
+                    onwarn: (warning) => {
+                        if(warning.code === 'CIRCULAR_DEPENDENCY') return
+                    },
+                    output: {
+                        chunkFileNames: 'assets/js/[name]-[hash].js',
+                        entryFileNames: 'assets/js/[name]-[hash].js',
+                        assetFileNames: 'assets/[ext]/[name]-[hash].[ext]',
+                        manualChunks(id) {
+                            if (id.includes('node_modules')) {
+                                // 让每个插件都打包成独立的文件
+                                return id.toString().split('node_modules/')[1].split('/')[0].toString()
+                            }
+                        }
                     }
                 }
             }
         }
     }
-})
+}
+
+// https://vite.dev/config/
+/** @type {import('vite').UserConfig} */
+export default defineConfig(configFactory(resolve(__dirname, 'dist')))


### PR DESCRIPTION
之前写的qface复制有些问题，会重复复制图片...刚发现，修复了这个问题
然后增加了`VITE_LOCAL_FACE`，设置为false时将使用QFace项目自身的url，不再复制qface，进一步压缩空间

## Sourcery 摘要

在 `vite.config.ts` 中引入一个配置工厂，用于有条件地复制 QFace 资产并解决重复的图像复制问题；将 `VITE_LOCAL_FACE` 环境变量通过 Vite 和 Emoji 模型连接起来，以选择本地或远程资产；调整 Electron 渲染器配置以使用共享工厂；并添加一个预览命令。

新功能：
- 添加 `VITE_LOCAL_FACE` 标志，用于在本地和远程 QFace 资产 URL 之间切换

错误修复：
- 修复构建过程中重复复制 QQ 表情图片的问题

改进：
- 重构 `vite.config.ts` 以使用 `configFactory`，并为 APNG 和 Lottie 资产动态生成静态复制目标
- 重构 Emoji 模型，根据环境变量标志将 URL 生成集中到 `getNormalUrl` 和 `getSuperUrl` 方法中
- 更新 `electron.vite.config.ts` 以重用共享的 `configFactory` 进行渲染器构建

杂项：
- 在 `package.json` 中添加一个预览脚本

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configuration factory in vite.config.ts to conditionally copy QFace assets and address duplicated image copies, wire the VITE_LOCAL_FACE environment flag through both Vite and the Emoji model for selecting local vs remote assets, adapt the Electron renderer config to use the shared factory, and add a preview command.

New Features:
- Add VITE_LOCAL_FACE flag to toggle between local and remote QFace asset URLs

Bug Fixes:
- Fix duplicate copying of QQ-face images during the build

Enhancements:
- Refactor vite.config.ts to use a configFactory and dynamically generate static copy targets for APNG and Lottie assets
- Refactor Emoji model to centralize URL generation into getNormalUrl and getSuperUrl methods based on the environment flag
- Update electron.vite.config.ts to reuse the shared configFactory for renderer builds

Chores:
- Add a preview script to package.json

</details>