### PR TITLE
feat: 批量撤回与重新编辑自己撤回的消息

### DIFF
--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -164,3 +164,10 @@ set_group_title:
 # 设置消息回应
 send_respond:
     name: set_group_reaction
+
+
+
+# 我的lgr啊，你怎么似了？？？呜呜呜～～～祈祷有天可以复活吧
+# 撤回消息
+delete_msg:
+    name: delete_msg

--- a/src/renderer/src/assets/pathMap/NapCat.Onebot.yaml
+++ b/src/renderer/src/assets/pathMap/NapCat.Onebot.yaml
@@ -211,3 +211,7 @@ set_group_title:
 # 禁言成员
 ban_mumber:
     name: set_group_ban
+
+# 撤回消息
+delete_msg:
+    name: delete_msg

--- a/src/renderer/src/components/NoticeBody.vue
+++ b/src/renderer/src/components/NoticeBody.vue
@@ -12,6 +12,12 @@
             <a>{{ info.name }}</a>
             <span>{{ $t('撤回了一条消息') }}</span>
             <div />
+            <a
+                v-if="data.originMsg"
+                @click="$emit('reedit', data.originMsg)"
+            >
+                {{ $t('重新编辑') }}
+            </a>
         </div>
         <div v-else-if="data.notice_type == 'group_ban'" class="note-ban note-base">
             <template v-if="data.sub_type === 'ban'">
@@ -57,11 +63,12 @@
         getTrueLang,
     } from '@renderer/function/utils/systemUtil'
     import { pokeAnime } from '@renderer/function/utils/msgUtil'
-import { backend } from '@renderer/runtime/backend'
+    import { backend } from '@renderer/runtime/backend'
 
     export default defineComponent({
         name: 'NoticeBody',
         props: ['data', 'id'],
+        emits: ['reedit'],
         data() {
             return {
                 trueLang: getTrueLang(),

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -63,13 +63,13 @@ import { getPinyin } from './utils/pinyin'
 
 const popInfo = new PopInfo()
 // eslint-disable-next-line
-const msgPaths = import.meta.glob("@renderer/assets/pathMap/*.yaml", { eager: true})
+const msgPaths = import.meta.glob("@renderer/assets/pathMap/*.yaml", { eager: true })
 // 取出包含 Lagrange.OneBot.yaml 的那条
 const msgPathAt = Object.keys(msgPaths).find((item) => {
     return item.indexOf('Lagrange.OneBot.yaml') > 0
 })
 let msgPath = {} as { [key: string]: any }
-if(msgPathAt != undefined) {
+if (msgPathAt != undefined) {
     msgPath = (msgPaths[msgPathAt] as any).default
 }
 // 其他 tag
@@ -177,10 +177,10 @@ const noticeFunctions = {
                 // eslint-disable-next-line no-console
                 console.log(
                     '%c消失了一个好友：' +
-                        msg.nickname +
-                        '（' +
-                        msg.user_id +
-                        '）',
+                    msg.nickname +
+                    '（' +
+                    msg.user_id +
+                    '）',
                     'color:red;',
                 )
                 break
@@ -239,7 +239,7 @@ const noticeFunctions = {
      */
     kick: (_: string, msg: { [key: string]: any }) => {
         const groupId = msg.group_id
-        if(groupId == runtimeData.chatInfo.show.id) {
+        if (groupId == runtimeData.chatInfo.show.id) {
             // 稍微等一下再刷新成员列表
             delay(1000).then(() => {
                 Connector.send(
@@ -298,7 +298,7 @@ const noticeFunctions = {
             info.forEach((item: any) => {
                 switch (item.type) {
                     case 'img':
-                        str += `<img src="${ backend.proxyUrl(item.src) }"/>`
+                        str += `<img src="${backend.proxyUrl(item.src)}"/>`
                         break
                     case 'nor':
                         str += item.txt
@@ -350,7 +350,7 @@ const noticeFunctions = {
     input_status: (_: string, msg: { [key: string]: any }) => {
         const { $t } = app.config.globalProperties
         const sender = msg.user_id
-        if(runtimeData.chatInfo.show.id == sender) {
+        if (runtimeData.chatInfo.show.id == sender) {
             runtimeData.chatInfo.show.appendInfo = $t('对方正在输入……')
             setTimeout(() => {
                 runtimeData.chatInfo.show.appendInfo = undefined
@@ -442,7 +442,7 @@ const msgFunctions = {
                 value: data.nickname,
             })
             const title = `${data.nickname} `
-            if(backend.platform == 'web') {
+            if (backend.platform == 'web') {
                 document.title = title + '- Stapxs QQ Lite'
             } else {
                 document.title = title
@@ -535,19 +535,19 @@ const msgFunctions = {
             let name: string
             if (item.card != undefined && item.card != '') {
                 name = item.card
-            }else if (item.nickname != undefined && item.nickname != '') {
+            } else if (item.nickname != undefined && item.nickname != '') {
                 name = item.nickname
-            }else{
+            } else {
                 name = item.user_id.toString()
             }
 
             // 获取拼音首字母
             const first = name.substring(0, 1)
             item.py_start = getPinyin(first)
-                                .main
-                                .at(0)
-                                ?.substring(0, 1)
-                                .toUpperCase() ?? ' '
+                .main
+                .at(0)
+                ?.substring(0, 1)
+                .toUpperCase() ?? ' '
         })
         // 筛选列表
         const adminList = data.filter((item: GroupMemberInfoElem) => {
@@ -601,7 +601,7 @@ const msgFunctions = {
             return
         }
         const pan = document.getElementById('msgPan')
-        if(pan) {
+        if (pan) {
             const oldScrollHeight = pan.scrollHeight
             saveMsg(msg, 'top').then(() => {
                 nextTick(() => {
@@ -624,7 +624,7 @@ const msgFunctions = {
     ) => {
         const id = Number(echoList[1])
         if (id) {
-                try {
+            try {
                 // 对消息进行一次格式化处理
                 let list = getMsgData('message_list', msg, msgPath.message_list)
                 if (list != undefined) {
@@ -634,10 +634,10 @@ const msgFunctions = {
                         msgPath.message_value,
                     )
                     const raw = getMsgRawTxt(list[0])
-                    const {time} = list[0]
+                    const { time } = list[0]
                     // 更新消息列表
                     const onmsg = runtimeData.baseOnMsgList.get(Number(id))
-                    if(onmsg) {
+                    if (onmsg) {
                         onmsg.raw_msg = raw
                         onmsg.time = getViewTime(Number(time))
                         runtimeData.baseOnMsgList.set(id, onmsg)
@@ -738,8 +738,8 @@ const msgFunctions = {
         // runtimeData.chatInfo.info.user_info =
         //     msg.data.data.result.buddy.info_list[0]
         const data = getMsgData('friend_info', msg, msgPath.friend_info)[0]
-		data.regTime = new Date(data.reg_time).getTime()
-        if(data) {
+        data.regTime = new Date(data.reg_time).getTime()
+        if (data) {
             runtimeData.chatInfo.info.user_info = data
         }
     },
@@ -758,7 +758,7 @@ const msgFunctions = {
             const img = markRaw(new Img(
                 `https://p.qlogo.cn/gdynamic/${notice.img_id}/0/`
             ))
-            if(lastImg) img.insertPrev(lastImg)
+            if (lastImg) img.insertPrev(lastImg)
             notice.img = img
             lastImg = img
         }
@@ -796,7 +796,7 @@ const msgFunctions = {
 
         // 默认使用主目录相同的结构，如果存在子目录结构的定义则使用子目录的结构
         let map = msgPath.group_files
-        if(msgPath.group_folder_files.source) {
+        if (msgPath.group_folder_files.source) {
             map = msgPath.group_folder
         }
         const list = getMsgData('group_files', msg, map) as (GroupFileElem & GroupFileFolderElem)[]
@@ -891,8 +891,8 @@ const msgFunctions = {
         const onProcess = function (event: ProgressEvent): undefined {
             if (!event.lengthComputable) return
             const percent = Math.floor((event.loaded / event.total) * 100)
-            if(listItem) {
-                if(listItem.download_percent == undefined) {
+            if (listItem) {
+                if (listItem.download_percent == undefined) {
                     listItem.download_percent = 0
                 }
                 listItem.download_percent = percent
@@ -901,7 +901,7 @@ const msgFunctions = {
 
         // 下载文件
         downloadFile(url, fileName, onProcess, () => {
-            if(listItem) {
+            if (listItem) {
                 listItem.download_percent = undefined
             }
         })
@@ -1187,14 +1187,14 @@ const msgFunctions = {
 }
 
 const handlers: Record<string, (payload: any, metaArgs?: string[]) => void> = {
-  ...(Object.entries(msgFunctions).reduce((acc, [key, fn]) => ({
-    ...acc,
-    [key]: (payload: any, metaArgs?: string[]) => fn(key, payload, metaArgs)
-  }), {})),
-  ...(Object.entries(noticeFunctions).reduce((acc, [key, fn]) => ({
-    ...acc,
-    [key]: (payload: any) => fn(key, payload)
-  }), {}))
+    ...(Object.entries(msgFunctions).reduce((acc, [key, fn]) => ({
+        ...acc,
+        [key]: (payload: any, metaArgs?: string[]) => fn(key, payload, metaArgs)
+    }), {})),
+    ...(Object.entries(noticeFunctions).reduce((acc, [key, fn]) => ({
+        ...acc,
+        [key]: (payload: any) => fn(key, payload)
+    }), {}))
 };
 
 // ==========================================
@@ -1235,7 +1235,7 @@ function saveUser(msg: { [key: string]: any }, type: string) {
     if (list != undefined) {
         const groupNames = {} as { [key: number]: string }
         list.forEach((item, index) => {
-            if(item.group_name  == null || item.group_name == undefined) {
+            if (item.group_name == null || item.group_name == undefined) {
                 item.group_name = ''
             }
             // 为所有项目追加拼音名称
@@ -1248,10 +1248,10 @@ function saveUser(msg: { [key: string]: any }, type: string) {
             if (list?.[index]) {
                 list[index].py_name = getPinyin(pyMatchName)
                 list[index].py_start = list[index]
-                                        .py_name
-                                        .main.at(0)
-                                        ?.substring(0, 1)
-                                        .toUpperCase() ?? ' '
+                    .py_name
+                    .main.at(0)
+                    ?.substring(0, 1)
+                    .toUpperCase() ?? ' '
             }
             // 构建分类
             if (type == 'friend') {
@@ -1485,7 +1485,7 @@ async function msgPreprocess(msg: any): Promise<any> {
                     id: data['meta']['detail']['resid'],
                 }]
             }
-        } catch (e){/**/}
+        } catch (e) {/**/ }
     }
     //#endregion
 
@@ -1494,7 +1494,7 @@ async function msgPreprocess(msg: any): Promise<any> {
         const forwardId = msg.message.at(0).id
         if (forwardId) {
             try {
-                if(msg.message.at(0).content && msg.message.at(0).content.length > 0) {
+                if (msg.message.at(0).content && msg.message.at(0).content.length > 0) {
                     // 如果 content 里已经有内容了就直接用 content 里的内容
                     const data = await getMessageList(msg.message.at(0).content)
                     if (data) msg.message.at(0).content = data
@@ -1504,10 +1504,10 @@ async function msgPreprocess(msg: any): Promise<any> {
                     const data = await getMessageList(originData)
                     if (data) msg.message.at(0).content = data
                 }
-            }catch (e) {
+            } catch (e) {
                 logger.error(e as unknown as Error, '合并转发解析失败')
             }
-        }else {
+        } else {
             msg.message.at(0).content = []
         }
     }
@@ -1516,7 +1516,7 @@ async function msgPreprocess(msg: any): Promise<any> {
     //#region == lgr 商场表情 =============================
     // 过滤掉mface后面尾随的字符串
     const filter: any[] = []
-    for (let id = 0;id < msg.message.length;id++) {
+    for (let id = 0; id < msg.message.length; id++) {
         const seg = msg.message[id]
         filter.push(seg)
         if (seg.type === 'mface') id++
@@ -1527,40 +1527,35 @@ async function msgPreprocess(msg: any): Promise<any> {
 }
 
 function revokeMsg(_: string, msg: any) {
-    const chatId =
-        msg.notice_type.indexOf('group') >= 0 ? msg.group_id : msg.user_id
-    const msgId = msg.message_id
+    // 清除通知
+    const chatId = msg.notice_type.includes('group') ? msg.group_id : msg.user_id
+    new Notify().closeAll(chatId)
+
     // 寻找消息
+    const msgId = msg.message_id
     let msgGet = null as { [key: string]: any } | null
-    let msgIndex = -1
-    runtimeData.messageList.forEach((item, index) => {
-        if (item.message_id === msgId) {
-            msgGet = item
+    let msgIndex!: number
+    for (const [index, msg] of runtimeData.messageList.entries()) {
+        if (msg.message_id === msgId) {
+            msgGet = msg
             msgIndex = index
         }
-    })
-    if (msgGet !== null && msgIndex !== -1) {
-        runtimeData.messageList[msgIndex].revoke = true
-        if (
-            runtimeData.messageList[msgIndex].sender.user_id !=
-            runtimeData.loginInfo.uin
-        ) {
-            runtimeData.messageList.splice(msgIndex, 1)
-        }
-        if (msgGet.sender.user_id !== runtimeData.loginInfo.uin) {
-            // 显示撤回提示
-            const list = runtimeData.messageList
-            if (msgIndex !== -1) {
-                list.splice(msgIndex + 1, 0, msg)
-            } else {
-                list.push(msg)
-            }
-        }
-    } else {
-        logger.add(LogType.UI, '没有找到这条被撤回的消息', undefined)
     }
-    // 撤回通知
-    new Notify().closeAll(chatId)
+
+    if (!msgGet) {
+        logger.add(LogType.UI, '没有找到这条被撤回的消息')
+        return
+    }
+
+    // 移除消息
+    runtimeData.messageList.splice(msgIndex, 1)
+
+    if (msgGet.sender.user_id === runtimeData.loginInfo.uin)
+        msg.originMsg = msgGet
+
+    // 显示撤回提示
+    const list = runtimeData.messageList
+    list.splice(msgIndex + 1, 0, msg)
 }
 
 let qed_try_times = 0
@@ -1694,7 +1689,7 @@ function newMsg(_: string, data: any) {
         }
 
         // 群收纳箱 ============================================
-        if(runtimeData.sysConfig.bubble_sort_user) {
+        if (runtimeData.sysConfig.bubble_sort_user) {
             // 刷新群收纳箱列表
             let getGroup = runtimeData.baseOnMsgList.get(Number(id))
             // ( 如果 是群组消息 && 群组没有开启通知 && 不是置顶的 ) 这种情况下将群消息添加到群收纳盒中
@@ -1706,7 +1701,7 @@ function newMsg(_: string, data: any) {
             }
             if (getGroup) {
                 getGroup.message_id = data.message_id
-                const name = data.sender.card && data.sender.card !== ''? data.sender.card: data.sender.nickname
+                const name = data.sender.card && data.sender.card !== '' ? data.sender.card : data.sender.nickname
                 getGroup.raw_msg = name + ': ' + getMsgRawTxt(data)
                 getGroup.raw_msg_base = getMsgRawTxt(data)
                 getGroup.time = getViewTime(Number(data.time))
@@ -1765,10 +1760,10 @@ function newMsg(_: string, data: any) {
 
                     title: data.group_name ?? data.sender.nickname,
                     body:
-                        data.message_type === 'group'? data.sender.nickname + ':' + raw: raw,
+                        data.message_type === 'group' ? data.sender.nickname + ':' + raw : raw,
                     tag: `${id}/${data.message_id}`,
                     icon:
-                        data.message_type === 'group'? `https://p.qlogo.cn/gh/${id}/${id}/0`: `https://q1.qlogo.cn/g?b=qq&s=0&nk=${id}`,
+                        data.message_type === 'group' ? `https://p.qlogo.cn/gh/${id}/${id}/0` : `https://q1.qlogo.cn/g?b=qq&s=0&nk=${id}`,
                     image: undefined as any,
                     type: data.group_id ? 'group' : 'user',
                     is_important: isImportant,
@@ -1813,10 +1808,10 @@ function newMsg(_: string, data: any) {
                     runtimeData.baseOnMsgList.set(Number(id), showUser)
                 }
             }
-            if(id !== showId) {
+            if (id !== showId) {
                 const user = runtimeData.baseOnMsgList.get(id)
                 if (user) {
-                    if(!user.new_msg) {
+                    if (!user.new_msg) {
                         user.new_msg = true
                         runtimeData.newMsgCount++
                     }
@@ -1829,7 +1824,7 @@ function newMsg(_: string, data: any) {
 
         // 消息列表 ============================================
         // 刷新消息列表
-        if(!runtimeData.sysConfig.bubble_sort_user && data.message_type === 'group') {
+        if (!runtimeData.sysConfig.bubble_sort_user && data.message_type === 'group') {
             const getList = runtimeData.userList.filter((item) => {
                 return item.group_id === id
             })
@@ -1841,22 +1836,22 @@ function newMsg(_: string, data: any) {
             }
         }
         // 刷新消息
-        if(get) {
+        if (get) {
             const item = runtimeData.baseOnMsgList.get(Number(id))
-            if(item) {
+            if (item) {
                 item.message_id = data.message_id
                 if (data.message_type === 'group') {
                     const name =
-                        data.sender.card && data.sender.card !== ''? data.sender.card: data.sender.nickname
+                        data.sender.card && data.sender.card !== '' ? data.sender.card : data.sender.nickname
                     item.raw_msg = name + ': ' + getMsgRawTxt(data)
                 } else {
                     item.raw_msg = getMsgRawTxt(data)
                 }
                 item.time = getViewTime(Number(data.time))
-                if(id != showId) {
-                    if(data.atme) { item.highlight = $t('[有人@你]') }
-                    if(data.atall) { item.highlight = $t('[@全体]') }
-                    if(isImportant) { item.highlight = $t('[特別关心]') }
+                if (id != showId) {
+                    if (data.atme) { item.highlight = $t('[有人@你]') }
+                    if (data.atall) { item.highlight = $t('[@全体]') }
+                    if (isImportant) { item.highlight = $t('[特別关心]') }
                 }
                 runtimeData.baseOnMsgList.set(Number(id), item)
             }
@@ -1887,15 +1882,15 @@ function updateSysInfo(
 // ==============================================================
 
 function formatMessageData(data: any, isGroup: boolean) {
-    const name = data.sender.card && data.sender.card !== '' ? data.sender.card: data.sender.nickname
+    const name = data.sender.card && data.sender.card !== '' ? data.sender.card : data.sender.nickname
 
     return {
-      message_id: data.message_id,
-      raw_msg: isGroup ? `${name}: ${getMsgRawTxt(data)}` : getMsgRawTxt(data),
-      time: getViewTime(Number(data.time)),
-      raw_msg_base: getMsgRawTxt(data)
+        message_id: data.message_id,
+        raw_msg: isGroup ? `${name}: ${getMsgRawTxt(data)}` : getMsgRawTxt(data),
+        time: getViewTime(Number(data.time)),
+        raw_msg_base: getMsgRawTxt(data)
     }
-  }
+}
 
 const baseRuntime = {
     plantform: {} as any,
@@ -1953,7 +1948,7 @@ const baseRuntime = {
     messageList: [],
     popBoxList: [],
     mergeMsgStack: [],
-	inch: getInch(),
+    inch: getInch(),
 }
 
 export const runtimeData: RunTimeDataElem = reactive(baseRuntime)

--- a/src/renderer/src/function/utils/msgUtil.ts
+++ b/src/renderer/src/function/utils/msgUtil.ts
@@ -167,7 +167,7 @@ export function parseMsgList(
                         map,
                     )
                     // 如果 data 里有 type 字段，改成 type_item
-                    if(data[0] && data[0]['type'] != undefined) {
+                    if (data[0] && data[0]['type'] != undefined) {
                         data[0]['type_item'] = data[0]['type']
                         delete data[0]['type']
                     }
@@ -244,7 +244,7 @@ export function getMsgRawTxt(data: any): string {
                             if (user) {
                                 back +=
                                     '@' +
-                                    (user.card && user.card != ''? user.card: user.nickname)
+                                    (user.card && user.card != '' ? user.card : user.nickname)
                                 break
                             }
                         }
@@ -408,7 +408,7 @@ export function sendMsgRaw(
     echo = 'sendMsgBack',
 ) {
     // 如果消息为空则不发送
-    if(msg == undefined || msg == '' || (Array.isArray(msg) && msg.length == 0)) {
+    if (msg == undefined || msg == '' || (Array.isArray(msg) && msg.length == 0)) {
         return
     }
     // 预发送消息
@@ -419,7 +419,7 @@ export function sendMsgRaw(
         preShowMsg.forEach((item: any) => {
             // 对 base64 图片做特殊处理
             if (item.type == 'image') {
-                if(!item.file.startsWith('http')) {
+                if (item.file.startsWith('base64://')) {
                     const b64Str = (item.file as string).substring(9)
                     item.url = 'data:image/png;base64,' + b64Str
                 } else {
@@ -470,7 +470,7 @@ export function sendMsgRaw(
         }
     }
     if (msg !== undefined && msg.length > 0) {
-        if (runtimeData.jsonMap.name === 'Lagrange.OneBot'){
+        if (runtimeData.jsonMap.name === 'Lagrange.OneBot') {
             lgrSendMsg(id, msg, type, echo + '_uuid_' + msgUUID)
             sendStatEvent('send_msg', { type: type })
             return
@@ -479,7 +479,7 @@ export function sendMsgRaw(
             case 'group':
                 Connector.send(
                     runtimeData.jsonMap.message_list.name_group_send ??
-                        'send_msg',
+                    'send_msg',
                     { group_id: id, message: msg },
                     echo + '_uuid_' + msgUUID,
                 )
@@ -488,7 +488,7 @@ export function sendMsgRaw(
                 if (String(id).indexOf('/') > 1) {
                     Connector.send(
                         runtimeData.jsonMap.message_list.name_temp_send ??
-                            'send_temp_msg',
+                        'send_temp_msg',
                         {
                             user_id: id.split('/')[0],
                             group_id: id.split('/')[1],
@@ -499,7 +499,7 @@ export function sendMsgRaw(
                 } else {
                     Connector.send(
                         runtimeData.jsonMap.message_list.name_user_send ??
-                            'send_msg',
+                        'send_msg',
                         { user_id: id, message: msg },
                         echo + '_uuid_' + msgUUID,
                     )
@@ -563,7 +563,7 @@ export function updateBaseOnMsgList() {
 
     let onMsgList = [] as any[]
     let groupAssistList = [] as any[]
-    if(runtimeData.sysConfig.bubble_sort_user) {
+    if (runtimeData.sysConfig.bubble_sort_user) {
         // 将 normalList 进行拆分
         onMsgList = topList.concat(normalList.filter((item) => {
             return item.group_id && canGroupNotice(item.group_id) ||
@@ -600,11 +600,11 @@ export function canGroupNotice(id: number) {
  * @param windowInfo 窗口信息，在 electron 中使用
  */
 export function pokeAnime(animeBody: HTMLElement | null, windowInfo = null as {
-            x: number
-            y: number
-            width: number
-            height: number
-        } | null) {
+    x: number
+    y: number
+    width: number
+    height: number
+} | null) {
     if (animeBody) {
         const timeLine = anime.timeline({ targets: animeBody })
         // 如果窗口小于 500px 播放完整的动画（手机端样式）
@@ -623,7 +623,7 @@ export function pokeAnime(animeBody: HTMLElement | null, windowInfo = null as {
         timeLine.add({ translateX: [-10, 10, -5, 5, 0], duration: 500, easing: 'cubicBezier(.44,.09,.53,1)' })
         timeLine.change = async () => {
             if (animeBody) {
-                animeBody.parentElement?.parentElement?.classList.add( 'poking')
+                animeBody.parentElement?.parentElement?.classList.add('poking')
                 const teansformX = animeBody.style.transform
                 // teansformX 的数字可能是科学计数法，需要转换为普通数字
                 let num = Number((teansformX.match(/-?\d+\.?\d*/g) ?? [0])[0])
@@ -632,9 +632,9 @@ export function pokeAnime(animeBody: HTMLElement | null, windowInfo = null as {
                 // 输出 translateX
                 if (backend.isDesktop() && windowInfo) {
                     await backend.call(undefined, 'win:move', false, {
-                            x: windowInfo.x + num,
-                            y: windowInfo.y,
-                        })
+                        x: windowInfo.x + num,
+                        y: windowInfo.y,
+                    })
                 }
             }
         }
@@ -718,7 +718,7 @@ export function qqLevelIcons(level) {
  */
 export function qqLevelToEmoji(level) {
     const rawLevel = level
-    if(level <= 0) return level
+    if (level <= 0) return level
 
     const crown = Math.floor(level / 64);
     level %= 64;
@@ -740,60 +740,60 @@ export function qqLevelToEmoji(level) {
  * @param imageUrl 图片 URL
  */
 export async function getImageUrlData(imageUrl: string): Promise<{ buffer: Uint8Array, blob: Blob }> {
-  return new Promise((resolve, reject) => {
-    const img = new Image()
+    return new Promise((resolve, reject) => {
+        const img = new Image()
 
-    img.onload = () => {
-      try {
-        // 创建 canvas 并设置尺寸
-        const canvas = document.createElement('canvas')
-        canvas.width = img.width
-        canvas.height = img.height
+        img.onload = () => {
+            try {
+                // 创建 canvas 并设置尺寸
+                const canvas = document.createElement('canvas')
+                canvas.width = img.width
+                canvas.height = img.height
 
-        // 获取 2D 上下文并绘制图片
-        const ctx = canvas.getContext('2d')
-        if (!ctx) {
-          reject(new Error('无法获取 Canvas 上下文'))
-          return
+                // 获取 2D 上下文并绘制图片
+                const ctx = canvas.getContext('2d')
+                if (!ctx) {
+                    reject(new Error('无法获取 Canvas 上下文'))
+                    return
+                }
+
+                ctx.drawImage(img, 0, 0)
+
+                // 将 canvas 转换为 PNG 格式的 blob
+                canvas.toBlob((blob) => {
+                    if (!blob) {
+                        reject(new Error('图片转换失败'))
+                        return
+                    }
+
+                    // 读取 blob 为 ArrayBuffer，然后转换为 Uint8Array
+                    const reader = new FileReader()
+                    reader.onload = () => {
+                        const arrayBuffer = reader.result as ArrayBuffer
+                        resolve({
+                            buffer: new Uint8Array(arrayBuffer),
+                            blob: blob
+                        }
+                        )
+                    }
+                    reader.onerror = () => {
+                        reject(new Error('读取图片数据失败'))
+                    }
+                    reader.readAsArrayBuffer(blob)
+                }, 'image/png') // 强制转换为 PNG 格式
+            } catch (error) {
+                reject(error)
+            }
         }
 
-        ctx.drawImage(img, 0, 0)
+        img.onerror = () => {
+            reject(new Error('图片加载失败'))
+        }
 
-        // 将 canvas 转换为 PNG 格式的 blob
-        canvas.toBlob((blob) => {
-          if (!blob) {
-            reject(new Error('图片转换失败'))
-            return
-          }
-
-          // 读取 blob 为 ArrayBuffer，然后转换为 Uint8Array
-          const reader = new FileReader()
-          reader.onload = () => {
-            const arrayBuffer = reader.result as ArrayBuffer
-            resolve({
-                buffer: new Uint8Array(arrayBuffer),
-                blob: blob
-            }
-            )
-          }
-          reader.onerror = () => {
-            reject(new Error('读取图片数据失败'))
-          }
-          reader.readAsArrayBuffer(blob)
-        }, 'image/png') // 强制转换为 PNG 格式
-      } catch (error) {
-        reject(error)
-      }
-    }
-
-    img.onerror = () => {
-      reject(new Error('图片加载失败'))
-    }
-
-    // 处理跨域问题
-    img.crossOrigin = 'anonymous'
-    img.src = imageUrl
-  })
+        // 处理跨域问题
+        img.crossOrigin = 'anonymous'
+        img.src = imageUrl
+    })
 }
 
 /**
@@ -801,9 +801,9 @@ export async function getImageUrlData(imageUrl: string): Promise<{ buffer: Uint8
  * @param msg
  */
 export function isDeleteMsg(msg: any): boolean {
-    if(!['message', 'message_sent'].includes(msg.post_type)) return false
-    if(msg.sender.user_id !== runtimeData.loginInfo.uin)return false
-    if(msg.raw_message !== '&#91;已删除&#93;')return false
+    if (!['message', 'message_sent'].includes(msg.post_type)) return false
+    if (msg.sender.user_id !== runtimeData.loginInfo.uin) return false
+    if (msg.raw_message !== '&#91;已删除&#93;') return false
     return true
 }
 
@@ -857,7 +857,7 @@ export function getDifferencesWithRanges(a: string, b: string) {
  * lgr专用发送消息，懒得写了，不做通用适配，胡乱应付下吧
  * @param msg 消息内容
  */
-function lgrSendMsg(id: string, msg: any, type: string, cb: string){
+function lgrSendMsg(id: string, msg: any, type: string, cb: string) {
     if (msg[0].type === 'node') {
         const sendMsgs = [] as any[]
         msg.forEach((item) => {
@@ -866,12 +866,12 @@ function lgrSendMsg(id: string, msg: any, type: string, cb: string){
                 data: {
                     user_id: item.data.user_id.toString(),
                     nickname: item.data.nickname,
-                    content: item.data.content.map((item)=>{
-                        const copy = {...item}
+                    content: item.data.content.map((item) => {
+                        const copy = { ...item }
                         delete copy.type
                         return {
                             type: item.type,
-                            data: {...copy}
+                            data: { ...copy }
                         }
                     }),
                 },
@@ -884,29 +884,29 @@ function lgrSendMsg(id: string, msg: any, type: string, cb: string){
                 { group_id: id, messages: sendMsgs },
                 cb,
             )
-        }else if (type === 'user') {
+        } else if (type === 'user') {
             Connector.send(
                 'send_private_forward_msg',
                 { user_id: id, messages: sendMsgs },
                 cb,
             )
-        }else {
+        } else {
             new PopInfo().add(PopType.ERR, 'lgr不支持匿名聊天')
         }
-    }else {
-        if (type === 'group'){
+    } else {
+        if (type === 'group') {
             Connector.send(
                 'send_group_msg',
                 { group_id: id, message: msg },
                 cb,
             )
-        }else if (type === 'user'){
+        } else if (type === 'user') {
             Connector.send(
                 'send_private_msg',
                 { user_id: id, message: msg },
                 cb,
             )
-        }else{
+        } else {
             new PopInfo().add(PopType.ERR, 'lgr不支持匿名聊天')
         }
     }

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -210,7 +210,8 @@
                                             <EmojiFace v-if="context.type === 'face'"
                                                 :emoji="Emoji.get(Number(context.data.id))" />
                                             <img v-if="context.type === 'image'"
-                                                :src="context.data.url">
+                                                :src="context.data.url"
+                                                @click="viewerEssImg(context.data.url)">
                                         </template>
                                     </div>
                                 </div>
@@ -457,6 +458,10 @@
                         <div><font-awesome-icon :icon="['fas', 'xmark']" /></div>
                         <a>{{ $t('撤回') }}</a>
                     </div>
+                    <div v-show="tags.menuDisplay.reedit" @click="reeditMsg">
+                        <div><font-awesome-icon :icon="['fas', 'pencil']" /></div>
+                        <a>{{ $t('重新编辑') }}</a>
+                    </div>
                     <div v-show="tags.menuDisplay.at"
                         @click="selectedMsg ? addSpecialMsg({ msgObj: { type: 'at', qq: Number(selectedMsg.sender.user_id) }, addText: true, }): '';
                                 toMainInput();
@@ -688,6 +693,7 @@ import { Img } from '@renderer/function/model/img'
                         copyImg: false,
                         downloadImg: false as string | false,
                         revoke: false,
+                        reedit: false,
                         at: true,
                         poke: false,
                         remove: false,
@@ -1313,6 +1319,8 @@ import { Img } from '@renderer/function/model/img'
                             // 自己的消息、管理员和群主会显示撤回
                             this.tags.menuDisplay.revoke = true
                         }
+                        // 重新编辑判定
+                        this.tags.menuDisplay.reedit = this.tags.menuDisplay.revoke && data.sender.user_id === runtimeData.loginInfo.uin
                         if (data.revoke === true) {
                             // 已被撤回的自己的消息只显示复制
                             this.tags.menuDisplay.relpy = false
@@ -1429,6 +1437,7 @@ import { Img } from '@renderer/function/model/img'
                     downloadImg: false,
                     copyImg: false,
                     revoke: false,
+                    reedit: false,
                     at: false,
                     poke: false,
                     remove: false,
@@ -1800,12 +1809,37 @@ import { Img } from '@renderer/function/model/img'
              */
             async revokeMsg() {
                 const msg = this.selectedMsg
-                if (msg !== null) {
-                    const msgId = msg.message_id
-                    // 关闭消息菜单
-                    this.closeMsgMenu()
-                    await Connector.callApi('delete_msg', { message_id: msgId })
+
+                // 关闭消息菜单
+                this.closeMsgMenu()
+
+                if (!msg) {
+                    new PopInfo().add(PopType.ERR, this.$t('获取选中消息失败'))
+                    return
                 }
+
+                const msgId = msg.message_id
+                await Connector.callApi('delete_msg', { message_id: msgId })
+            },
+
+            /**
+             * 重新编辑消息
+             */
+            async reeditMsg() {
+                const msg = this.selectedMsg
+
+                // 关闭消息菜单
+                this.closeMsgMenu()
+
+                if (!msg) {
+                    new PopInfo().add(PopType.ERR, this.$t('获取选中消息失败'))
+                    return
+                }
+
+                const msgId = msg.message_id
+                await Connector.callApi('delete_msg', { message_id: msgId })
+
+                this.reedit(msg)
             },
 
             /**
@@ -2573,6 +2607,9 @@ import { Img } from '@renderer/function/model/img'
                 this.tags.menuDisplay.poke = false
             },
 
+            /**
+             * 重新编辑消息
+             */
             reedit(msg: any) {
                 this.msg = ''
                 this.sendCache = []
@@ -2620,6 +2657,14 @@ import { Img } from '@renderer/function/model/img'
                         )
                     }
                 }
+            },
+
+            /**
+             * 预览精华消息图片
+             */
+            viewerEssImg(url: string) {
+                if (!this.viewer) return
+                (this.viewer as any).open(new Img(url))
             },
 
             /**

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -109,7 +109,8 @@
                     <NoticeBody v-else-if="msgIndex.post_type === 'notice'"
                         :id="uuid()"
                         :key="'notice-' + index"
-                        :data="msgIndex" />
+                        :data="msgIndex"
+                        @reedit="reedit" />
                 </template>
             </TransitionGroup>
         </div>
@@ -237,6 +238,10 @@
                     <div>
                         <font-awesome-icon :icon="['fas', 'copy']" @click="copyMsgs" />
                         <span>{{ $t('复制') }}</span>
+                    </div>
+                    <div>
+                        <font-awesome-icon :icon="['fas', 'xmark']" @click="recallMsgs" />
+                        <span>{{ $t('撤回') }}</span>
                     </div>
                     <div>
                         <span @click="multipleSelectList = []">{{ multipleSelectList.length }}</span>
@@ -1793,13 +1798,13 @@ import { Img } from '@renderer/function/model/img'
             /**
              * 撤回消息
              */
-            revokeMsg() {
+            async revokeMsg() {
                 const msg = this.selectedMsg
                 if (msg !== null) {
                     const msgId = msg.message_id
-                    Connector.send('delete_msg', { message_id: msgId }, 'deleteMsg')
                     // 关闭消息菜单
                     this.closeMsgMenu()
+                    await Connector.callApi('delete_msg', { message_id: msgId })
                 }
             },
 
@@ -2454,6 +2459,22 @@ import { Img } from '@renderer/function/model/img'
             },
 
             /**
+             * 批量撤回消息
+             */
+            async recallMsgs() {
+                const msgList = this.list.filter((item: any) => this.multipleSelectList.includes(item.message_id))
+
+                const tasks: Promise<true | undefined>[] = []
+                for (const msg of msgList) {
+                    const msgId = msg.message_id
+                    tasks.push(Connector.callApi('delete_msg', { message_id: msgId }))
+                }
+                // 关闭多选菜单
+                this.multipleSelectList = []
+                await Promise.all(tasks)
+            },
+
+            /**
              * 获取显示群精华消息
              */
             showJin() {
@@ -2550,6 +2571,28 @@ import { Img } from '@renderer/function/model/img'
                 }
                 this.tags.showMoreDetail = false
                 this.tags.menuDisplay.poke = false
+            },
+
+            reedit(msg: any) {
+                this.msg = ''
+                this.sendCache = []
+                this.imgCache.clear()
+                this.cancelReply()
+                for (const seg of msg.message) {
+                    if (seg.type === 'text') {
+                        this.msg += seg.text
+                    } else if (seg.type === 'reply') {
+                        const msg = this.list.find((item: any) => item.message_id == seg.id)
+                        if (!msg) continue
+                        this.replyMsg(msg)
+                    } else {
+                        this.addSpecialMsg({
+                            addText: false,
+                            msgObj: seg,
+                        })
+                        this.msg += '[SQ:' + (this.sendCache.length - 1) + ']'
+                    }
+                }
             },
 
             /**


### PR DESCRIPTION
emm...ide开了自动格式化，所以`src/renderer/src/function/utils/msgUtil.ts`会有一大堆格式化...

## Summary by Sourcery

为消息批量撤回以及用户对自己已撤回消息的再次编辑提供支持，包括针对 OneBot 适配器的 `delete_msg` 映射以及一些小的交互优化。

新功能：
- 允许用户通过多选工具栏批量撤回选中的消息。
- 允许用户直接从撤回提示条目中重新编辑自己撤回的消息。

增强与改进：
- 将单条消息撤回切换为使用 `delete_msg` API 调用，并将 `delete_msg` 接入 Lagrange.OneBot 和 NapCat.OneBot 的路径映射。
- 将撤回通知从 `NoticeBody` 向上传递到聊天视图，并复用现有的消息编辑/发送流水线来实现对撤回内容的再次编辑。
- 整理消息工具相关代码格式，并在消息发送前处理阶段对 base64 图片的处理逻辑做了小幅调整。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for batch recalling messages and re-editing a user’s own recalled messages, including OneBot adapter mappings for delete_msg and minor UX adjustments.

New Features:
- Allow users to batch recall selected messages from the multi-select toolbar.
- Enable re-editing of a user’s own recalled message directly from the recall notice entry.

Enhancements:
- Switch single-message recall to use the delete_msg API call and wire delete_msg into Lagrange.OneBot and NapCat.OneBot path maps.
- Pass recall notices up from NoticeBody to the chat view and reuse the existing message composition pipeline for re-editing recalled content.
- Tidy up message utility code formatting and slightly adjust base64 image handling in message pre-send processing.

</details>