### PR TITLE
修复了一些关于输入框的Bug

### DIFF
--- a/src/renderer/src/assets/css/chat.css
+++ b/src/renderer/src/assets/css/chat.css
@@ -189,7 +189,12 @@ input {
     width: 20px;
 }
 .chat-pan > div.more > div:nth-child(2) > div:nth-child(2) {
-    align-items: end;
+    align-items: center;
+    display: flex;
+    flex: 1;
+}
+.chat-pan > div.more > div:nth-child(2) > div:nth-child(2) > form {
+    align-items: center;
     display: flex;
     flex: 1;
 }

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -798,16 +798,16 @@ import { Img } from '@renderer/function/model/img'
                     return
                 }
                 const computed = getComputedStyle(input)
-                const lineHeight = parseFloat(computed.lineHeight)
-                const fontSize = parseFloat(computed.fontSize)
+                const lineHeight = Number.parseFloat(computed.lineHeight)
+                const fontSize = Number.parseFloat(computed.fontSize)
                 const baseLineHeight = Number.isFinite(lineHeight) ? lineHeight : fontSize
-                const paddingTop = parseFloat(computed.paddingTop) || 0
-                const paddingBottom = parseFloat(computed.paddingBottom) || 0
-                const borderTop = parseFloat(computed.borderTopWidth) || 0
-                const borderBottom = parseFloat(computed.borderBottomWidth) || 0
+                const paddingTop = Number.parseFloat(computed.paddingTop) || 0
+                const paddingBottom = Number.parseFloat(computed.paddingBottom) || 0
+                const borderTop = Number.parseFloat(computed.borderTopWidth) || 0
+                const borderBottom = Number.parseFloat(computed.borderBottomWidth) || 0
                 let minHeight = (Number.isFinite(baseLineHeight) ? baseLineHeight : 0) + paddingTop + paddingBottom + borderTop + borderBottom
                 if (minHeight <= 0) {
-                    const fallback = input.offsetHeight || parseFloat(computed.height) || fontSize
+                    const fallback = input.offsetHeight || Number.parseFloat(computed.height) || fontSize
                     if (fallback && Number.isFinite(fallback)) {
                         minHeight = fallback
                     }
@@ -815,9 +815,9 @@ import { Img } from '@renderer/function/model/img'
                 if (!input.dataset.baseHeight) {
                     input.dataset.baseHeight = String(minHeight)
                 }
-                input.style.height = 'auto'
-                const baseHeight = parseFloat(input.dataset.baseHeight) || minHeight
-                const targetHeight = input.scrollHeight > baseHeight * 2 ? Math.max(input.scrollHeight, baseHeight): baseHeight
+                input.style.height = '0'
+                const baseHeight = Number.parseFloat(input.dataset.baseHeight) || minHeight
+                const targetHeight = Math.max(input.scrollHeight, baseHeight)
                 input.style.height = targetHeight + 'px'
             },
             jumpSearchMsg() {


### PR DESCRIPTION
- firefox内核浏览器输入框靠下不居中的问题
- 仅有两行时输入框不能自动调整高度

## Summary by Sourcery

修复跨浏览器的聊天输入框布局和自动调整大小行为。

Bug 修复：
- 确保聊天输入框在基于 Firefox 的浏览器中能够正确垂直居中。
- 修正聊天输入框自动高度逻辑，使其即使在只有两行文本时也能正常扩展。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix chat input layout and auto-resizing behavior across browsers.

Bug Fixes:
- Ensure the chat input vertically centers correctly in Firefox-based browsers.
- Correct the chat input auto-height logic so it expands properly even when only two lines of text are present.

</details>