### PR TITLE
对图片预览器的一些维护

### DIFF
--- a/src/renderer/src/assets/css/view.css
+++ b/src/renderer/src/assets/css/view.css
@@ -1355,7 +1355,6 @@ textarea:focus {
     opacity: 0.0;
 }
 
-
 .viewer-bar {
     position: absolute;
     z-index: 31;
@@ -1496,6 +1495,11 @@ textarea:focus {
     margin-top: auto !important;
     margin-bottom: auto !important;
     opacity: 0;
+}
+
+.viewer-bar.dragging {
+    opacity: 0;
+    pointer-events: none;
 }
 
 .viewer-img {

--- a/src/renderer/src/components/ViewerCom.vue
+++ b/src/renderer/src/components/ViewerCom.vue
@@ -10,7 +10,8 @@
                 @mousemove="mouseMoveCheck">
                 <!-- 工具扩展设置 -->
                 <TransitionGroup class="viewer-bar viewer-tool-config-bar"
-                    name="viewer-tool-config" tag="div">
+                    name="viewer-tool-config" tag="div"
+                    :class="{ dragging: dragging }">
                     <!-- 颜色 -->
                     <template v-if="currentTool !== 'hand'">
                         <div v-for="(color, key) in colorMap"
@@ -48,7 +49,8 @@
                             key="1"
                             class="viewer-bar viewer-button-bar"
                             :class="{
-                                'force-show': forceShowButton || moveTimeout
+                                'force-show': forceShowButton || moveTimeout,
+                                dragging: dragging,
                             }">
                             <font-awesome-icon v-hide="!prev"
                                 :icon="['fas', 'angle-left']"
@@ -74,6 +76,7 @@
                         <!-- 编辑栏 -->
                         <div v-else
                             key="2"
+                            :class="{dragging: dragging}"
                             class="viewer-bar viewer-button-bar force-show">
                             <font-awesome-icon :icon="['fas', 'hand']"
                                 :class="{ active: currentTool === 'hand' }"
@@ -242,6 +245,7 @@ const currentColor = computed(() => toolConfig[currentTool.value].color)
 const currentLineWidth = computed(() => toolConfig[currentTool.value].width)
 const loading = shallowRef(true)
 const edit = shallowRef(false)
+const dragging = shallowRef(false)
 const currentImgInfo = shallowRef<{
     width: number,                          // 图片实际宽度
     height: number,                         // 图片实际高度
@@ -811,6 +815,7 @@ let mouseDownTime = 0
 function onMouseDown(event: MouseEvent) {
     handleEvent(event)
     mouseDownTime = Date.now()
+    dragging.value = true
 
     switch (currentTool.value) {
         case 'hand':
@@ -843,6 +848,7 @@ function onMouseMove(event: MouseEvent) {
 }
 function onMouseUp(event: MouseEvent) {
     handleEvent(event)
+    dragging.value = false
 
     switch (currentTool.value) {
         case 'hand':
@@ -869,6 +875,7 @@ function onMouseout(event: MouseEvent) {
 let onImgTouchFlag = false
 function onImgTouchStart(event: TouchEvent) {
     if (event.touches.length !== 1) return
+    dragging.value = true
 
     mouseDownTime = Date.now()
 
@@ -907,6 +914,7 @@ function onImgTouchEnd(event: TouchEvent) {
     if (!onImgTouchFlag) return
     handleEvent(event)
     onImgTouchFlag = false
+    dragging.value = false
 
     // 点击判定
     onClick(event)

--- a/src/renderer/src/components/ViewerCom.vue
+++ b/src/renderer/src/components/ViewerCom.vue
@@ -731,9 +731,18 @@ function onScrollbarDrag(axis: 'x' | 'y', event: MouseEvent) {
     }
     mousemoveMask((event: MouseEvent) => {
         const move = getDeltaAndUpdate(event)
+        let imgWidth = 0
+        let imgHeight = 0
+        if (modify.rotate % 180 === 0) {
+            imgWidth = currentImgInfo.value?.width || 0
+            imgHeight = currentImgInfo.value?.height || 0
+        } else {
+            imgWidth = currentImgInfo.value?.height || 0
+            imgHeight = currentImgInfo.value?.width || 0
+        }
         if (axis === 'x') {
             // 横向滚动
-            modify.x -= move * (currentImgInfo.value?.width || 0) / (vw.value * 100)
+            modify.x -= move * imgWidth * modify.scale / (vw.value * 100)
             // 限制范围
             const info = currentImgInfo.value
             if (!info) return true
@@ -747,7 +756,7 @@ function onScrollbarDrag(axis: 'x' | 'y', event: MouseEvent) {
             }
         } else {
             // 纵向滚动
-            modify.y -= move * (currentImgInfo.value?.height || 0) / (vh.value * 100)
+            modify.y -= move * imgHeight * modify.scale / (vh.value * 100)
             const info = currentImgInfo.value
             if (!info) return true
             if (modify.rotate % 180 === 0) {

--- a/src/renderer/src/components/ViewerCom.vue
+++ b/src/renderer/src/components/ViewerCom.vue
@@ -993,7 +993,19 @@ function penMouseMove(x: number, y: number) {
     ctx.fill()
     penLastPoint = point
 }
-function penMouseUp(_x: number, _y: number) {
+function penMouseUp(x: number, y: number) {
+    if (!penLastPoint) return
+    const ctx = canvas.value?.getContext('2d')
+    if (!ctx) return
+    const point = getPos(x, y)
+    ctx.beginPath()
+    ctx.moveTo(penLastPoint.x, penLastPoint.y)
+    ctx.lineTo(point.x, point.y)
+    ctx.stroke()
+    // 末端整个圆，防止连接处出现裂缝
+    ctx.beginPath()
+    ctx.arc(point.x, point.y, currentLineWidth.value / 2, 0, Math.PI * 2)
+    ctx.fill()
     penLastPoint = undefined
 }
 
@@ -1024,6 +1036,9 @@ function rectMouseUp(x: number, y: number) {
     if (!rectStartPoint) return
     const ctx = canvas.value?.getContext('2d')
     if (!ctx) return
+    const lastImg = editHistory.at(-1)
+    if (!lastImg) return
+    ctx.putImageData(lastImg, 0, 0)
     const point = getPos(x, y)
     ctx.beginPath()
     ctx.rect(rectStartPoint.x, rectStartPoint.y, point.x - rectStartPoint.x, point.y - rectStartPoint.y)


### PR DESCRIPTION
- 拖拽滑轨时，移动距离计算不准确
- 处理越界时的一些bug
- 绘画时下方工具栏会挡手

## Summary by Sourcery

改进图像查看器中滚动条拖拽行为和绘制用户体验。

错误修复：
- 修正滚动条拖拽距离的计算，使其正确考虑图像旋转和缩放。
- 在绘制矩形时，先恢复之前的画布图像再渲染最终形状，以避免产生伪影。
- 在结束笔划前，先绘制最后一段线段和端点封盖，防止笔划末尾出现缝隙。

增强功能：
- 当用户进行拖拽时，隐藏并禁用查看器工具栏的交互，避免底部工具栏阻挡绘图手势。
- 添加共享的拖拽状态，在拖拽操作期间协调各工具栏的视觉状态和交互行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve image viewer scrollbar dragging behavior and drawing UX.

Bug Fixes:
- Correct scrollbar drag distance calculations to account for image rotation and zoom.
- Ensure rectangle drawing restores the previous canvas image before rendering the final shape to avoid artifacts.
- Prevent gaps at the end of pen strokes by drawing the final segment and end cap before finishing the stroke.

Enhancements:
- Hide and disable interaction with viewer toolbars while the user is dragging to avoid the bottom toolbar blocking drawing gestures.
- Add a shared dragging state to coordinate visual state and interaction across toolbars during drag operations.

</details>