### PR TITLE
fix: 频道卡片解析失败

### DIFF
--- a/src/renderer/src/components/msg-component/jsonComp/Forum.vue
+++ b/src/renderer/src/components/msg-component/jsonComp/Forum.vue
@@ -6,7 +6,7 @@
             <font-awesome-icon icon="message" /> {{ data.comment }}
             <font-awesome-icon icon="thumbs-up" /> {{ data.prefer }}
         </span>
-        <img :src="data.img" alt="" />
+        <img :src="data.img" alt="" class="forum-img" />
         <div class="bottom-bar">
             <img :src="data.icon" alt="" />
             <span>{{ data.name }} ({{ $t('频道') }})</span>
@@ -45,7 +45,7 @@ const music = z
                             width: z.number(),
                         }),
                     ),
-                    prefer_count: z.number(),
+                    prefer_count: z.number().optional(),
                     view_count: z.number(),
                 }),
                 jump_url: z.string(),
@@ -57,7 +57,7 @@ const music = z
         title: o.prompt.replace('[频道帖子]', ''),
         view: o.meta.detail.feed.view_count,
         comment: o.meta.detail.feed.comment_count,
-        prefer: o.meta.detail.feed.prefer_count,
+        prefer: o.meta.detail.feed.prefer_count ?? 0,
         jumpUrl: o.meta.detail.jump_url,
         img: o.meta.detail.feed.images[0]?.pic_url,
         icon: o.meta.detail.channel_info.guild_icon,
@@ -71,3 +71,11 @@ if (!success) {
     new Logger().error(parsedData.error, 'Card Parse Error')
 }
 </script>
+
+<style lang="css" scoped>
+.forum-img {
+    max-width: 30vw;
+    min-width: 240px;
+    object-fit: cover;
+}
+</style>


### PR DESCRIPTION
上次就抓了一个频道卡片研究...没想到这次遇到了一个和上次不一样的...

## Summary by Sourcery

在论坛频道卡片中处理可选的点赞数字段，并调整其图片展示方式。

Bug Fixes:
- 当论坛卡片数据缺少 `prefer_count` 字段时，将其视为可选字段，缺失时默认值设为 0，以防止解析失败。

Enhancements:
- 通过专用的 CSS 类限制论坛卡片图片的尺寸和纵横比，从而提升布局的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle optional like-count field in forum channel cards and adjust their image presentation.

Bug Fixes:
- Prevent parsing failures when forum card data lacks a prefer_count field by treating it as optional and defaulting missing values to zero.

Enhancements:
- Constrain forum card image size and aspect ratio via a dedicated CSS class to improve layout consistency.

</details>