### PR TITLE
卡片消息的一些更新

### DIFF
--- a/src/renderer/src/assets/css/msg.css
+++ b/src/renderer/src/assets/css/msg.css
@@ -562,9 +562,13 @@ div:has(> .msg-img.long-img)::after {
 }
 
 .msg-json > div.bottom-bar > span {
+    display: inline-block;
     font-size: 0.9rem;
     opacity: 0.7;
     margin-left: 7px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .msg-json > div.el-vue-amap-container {

--- a/src/renderer/src/components/msg-component/JsonSegComp.vue
+++ b/src/renderer/src/components/msg-component/JsonSegComp.vue
@@ -25,6 +25,7 @@ const comps = import.meta.glob('./jsonComp/*.vue', {
 const cardComponentMap = {
     'com.tencent.tuwen.lua': comps['./jsonComp/Tuwen.lua.vue'],
     'com.tencent.mannounce': comps['./jsonComp/Mannounce.vue'],
+    'com.tencent.miniapp.lua': comps['./jsonComp/Miniapp.lua.vue'],
     'com.tencent.miniapp_01': comps['./jsonComp/Miniapp.vue'],
     'com.tencent.music.lua': comps['./jsonComp/Music.lua.vue'],
     'com.tencent.contact.lua': comps['./jsonComp/Contact.lua.vue'],

--- a/src/renderer/src/components/msg-component/JsonSegComp.vue
+++ b/src/renderer/src/components/msg-component/JsonSegComp.vue
@@ -31,6 +31,7 @@ const cardComponentMap = {
     'com.tencent.map': comps['./jsonComp/Map.vue'],
     'com.tencent.forum': comps['./jsonComp/Forum.vue'],
     'com.tencent.autoreply': comps['./jsonComp/AutoReply.vue'],
+    'com.tencent.feed.lua': comps['./jsonComp/Feed.lua.vue'],
 }
 
 const { data } = defineProps<{

--- a/src/renderer/src/components/msg-component/jsonComp/AutoReply.vue
+++ b/src/renderer/src/components/msg-component/jsonComp/AutoReply.vue
@@ -32,7 +32,7 @@ const { data: jsonData, id } = defineProps<{
     id: string,
 }>()
 
-const music = z
+const autoReply = z
     .object({
         app: z.literal('com.tencent.autoreply'),
         meta: z.object({
@@ -58,7 +58,7 @@ const music = z
         })),
     }))
 const json = JSON.parse(jsonData)
-const parsedData = music.safeParse(json)
+const parsedData = autoReply.safeParse(json)
 const success = parsedData.success
 const parsedContent = parsedData.data!
 if (!success) {

--- a/src/renderer/src/components/msg-component/jsonComp/Contact.lua.vue
+++ b/src/renderer/src/components/msg-component/jsonComp/Contact.lua.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="success" class="msg-json">
+    <div v-if="success" class="msg-json" @click="open(parsedContent.jumpUrl)">
         <p>{{ parsedContent.title }}</p>
         <span v-if="parsedContent.type === 'group'">{{ parsedContent.desc }}</span>
         <img :src="parsedContent.img" alt="">
@@ -18,12 +18,18 @@
 
 <script setup lang="ts">
 import { Logger } from '@renderer/function/base';
+import { openLink } from '@renderer/function/utils/appUtil'
 import * as z from 'zod'
 
 const { data: jsonData, id } = defineProps<{
     data: string,
     id: string,
 }>()
+
+function open(url: string) {
+    if (!url.startsWith('http')) return
+    openLink(url)
+}
 
 const friend = z
     .object({
@@ -68,7 +74,28 @@ const group = z
         name: o.meta.contact.tag,
     }))
 
-const contact = z.union([friend, group])
+const bot = z
+    .object({
+        app: z.literal('com.tencent.contact.lua'),
+        meta: z.object({
+            contact: z.object({
+                avatar: z.string(),
+                nickname: z.string(),
+                contact: z.string(),
+                jumpUrl: z.string(),
+                tag: z.literal('机器人名片'),
+            }),
+        }),
+    })
+    .transform((o) => ({
+        type: 'bot' as const,
+        img: o.meta.contact.avatar,
+        title: o.meta.contact.nickname,
+        jumpUrl: o.meta.contact.jumpUrl,
+        name: o.meta.contact.tag,
+    }))
+
+const contact = z.union([friend, group, bot])
 
 const json = JSON.parse(jsonData)
 const parsedData = contact.safeParse(json)

--- a/src/renderer/src/components/msg-component/jsonComp/Feed.lua.vue
+++ b/src/renderer/src/components/msg-component/jsonComp/Feed.lua.vue
@@ -1,0 +1,93 @@
+<template>
+    <div class="msg-json" v-if="success" @click="openLink(parsedContent.jumpUrl)">
+        <p>{{ parsedContent.title }}</p>
+        <span>{{ parsedContent.desc }}</span>
+        <img :src="parsedContent.img" alt="" />
+        <div class="bottom-bar">
+            <img :src="parsedContent.icon" alt="" />
+            <span>{{ parsedContent.name }}</span>
+        </div>
+    </div>
+    <span v-else class="msg-unknown">{{
+        '( ' + $t('加载失败') + ': ' + id + ' )'
+    }}</span>
+</template>
+
+<script setup lang="ts">
+import { Logger } from '@renderer/function/base';
+import { openLink } from '@renderer/function/utils/appUtil'
+import * as z from 'zod'
+
+const { data: jsonData, id } = defineProps<{
+    data: string,
+    id: string,
+}>()
+
+/**
+ * 解包 Qzone 风格的嵌套 URL 链接
+ * @param url 原始的完整 URL 字符串
+ * @returns 解码后的内部链接，如果解析失败则返回 null
+ */
+function unpackNestedUrl(url: string): string | null {
+    try {
+        const urlObj = new URL(url)
+
+        // 1. 处理路径部分 (pathname)
+        // 示例路径: /groupphoto/inqq/detail/https%3A%2F%2F...
+        const pathname = urlObj.pathname
+
+        // 寻找 "detail/" 之后的部分，这是常见的 Qzone 嵌套模式
+        const detailMarker = 'detail/'
+        const markerIndex = pathname.indexOf(detailMarker)
+
+        if (markerIndex !== -1) {
+            // 截取 detail/ 之后的所有内容
+            const encodedPart = pathname.substring(
+                markerIndex + detailMarker.length,
+            )
+
+            // 进行 URL 解码
+            // 注意：decodeURIComponent 会处理 %3A, %2F, %26 等
+            return decodeURIComponent(encodedPart)
+        }
+
+        return null
+    } catch (error) {
+        logger.error(error as Error, 'URL 解包失败')
+        return null
+    }
+}
+
+const feed = z
+    .object({
+        app: z.literal('com.tencent.feed.lua'),
+        meta: z.object({
+            feed: z.object({
+                cover: z.string(),
+                title: z.string(),
+                tagIcon: z.string(),
+                tagName: z.string(),
+                forwardMessage: z.string(),
+                pcJumpUrl: z.string(),
+            }),
+        }),
+        prompt: z.string(),
+    })
+    .transform((o) => ({
+        title: o.meta.feed.title,
+        jumpUrl:
+            unpackNestedUrl(o.meta.feed.pcJumpUrl) ?? o.meta.feed.pcJumpUrl,
+        img: o.meta.feed.cover,
+        icon: o.meta.feed.tagIcon,
+        name: o.meta.feed.tagName,
+        desc: o.meta.feed.forwardMessage,
+    }))
+
+const json = JSON.parse(jsonData)
+const parsedData = feed.safeParse(json)
+const success = parsedData.success
+const parsedContent = parsedData.data!
+if (!success) {
+    new Logger().error(parsedData.error, 'Card Parse Error')
+}
+</script>

--- a/src/renderer/src/components/msg-component/jsonComp/Forum.vue
+++ b/src/renderer/src/components/msg-component/jsonComp/Forum.vue
@@ -6,7 +6,7 @@
             <font-awesome-icon icon="message" /> {{ parsedContent.comment }}
             <font-awesome-icon icon="thumbs-up" /> {{ parsedContent.prefer }}
         </span>
-        <img :src="parsedContent.img" alt="" class="forum-img">
+        <img v-if="parsedContent.img" :src="parsedContent.img" alt="" class="forum-img">
         <div class="bottom-bar">
             <img :src="parsedContent.icon" alt="">
             <span>{{ parsedContent.name }} ({{ $t('频道') }})</span>
@@ -38,13 +38,15 @@ const music = z
                 }),
                 feed: z.object({
                     comment_count: z.number(),
-                    images: z.array(
-                        z.object({
-                            pic_url: z.string(),
-                            height: z.number(),
-                            width: z.number(),
-                        }),
-                    ),
+                    images: z
+                        .array(
+                            z.object({
+                                pic_url: z.string(),
+                                height: z.number(),
+                                width: z.number(),
+                            }),
+                        )
+                        .optional(),
                     prefer_count: z.number().optional(),
                     view_count: z.number(),
                 }),
@@ -59,7 +61,7 @@ const music = z
         comment: o.meta.detail.feed.comment_count,
         prefer: o.meta.detail.feed.prefer_count ?? 0,
         jumpUrl: o.meta.detail.jump_url,
-        img: o.meta.detail.feed.images[0]?.pic_url,
+        img: o.meta.detail.feed.images?.[0]?.pic_url,
         icon: o.meta.detail.channel_info.guild_icon,
         name: o.meta.detail.channel_info.guild_name,
     }))

--- a/src/renderer/src/components/msg-component/jsonComp/Forum.vue
+++ b/src/renderer/src/components/msg-component/jsonComp/Forum.vue
@@ -37,7 +37,7 @@ const forum = z
                     guild_name: z.string(),
                 }),
                 feed: z.object({
-                    comment_count: z.number(),
+                    comment_count: z.number().optional(),
                     images: z
                         .array(
                             z.object({
@@ -48,7 +48,7 @@ const forum = z
                         )
                         .optional(),
                     prefer_count: z.number().optional(),
-                    view_count: z.number(),
+                    view_count: z.number().optional(),
                 }),
                 jump_url: z.string(),
             }),
@@ -57,8 +57,8 @@ const forum = z
     })
     .transform((o) => ({
         title: o.prompt.replace('[频道帖子]', ''),
-        view: o.meta.detail.feed.view_count,
-        comment: o.meta.detail.feed.comment_count,
+        view: o.meta.detail.feed.view_count ?? 0,
+        comment: o.meta.detail.feed.comment_count ?? 0,
         prefer: o.meta.detail.feed.prefer_count ?? 0,
         jumpUrl: o.meta.detail.jump_url,
         img: o.meta.detail.feed.images?.[0]?.pic_url,

--- a/src/renderer/src/components/msg-component/jsonComp/Forum.vue
+++ b/src/renderer/src/components/msg-component/jsonComp/Forum.vue
@@ -27,7 +27,7 @@ const { data: jsonData, id } = defineProps<{
     id: string,
 }>()
 
-const music = z
+const forum = z
     .object({
         app: z.literal('com.tencent.forum'),
         meta: z.object({
@@ -66,7 +66,7 @@ const music = z
         name: o.meta.detail.channel_info.guild_name,
     }))
 const json = JSON.parse(jsonData)
-const parsedData = music.safeParse(json)
+const parsedData = forum.safeParse(json)
 const success = parsedData.success
 const parsedContent = parsedData.data!
 if (!success) {

--- a/src/renderer/src/components/msg-component/jsonComp/Miniapp.lua.vue
+++ b/src/renderer/src/components/msg-component/jsonComp/Miniapp.lua.vue
@@ -1,0 +1,54 @@
+<template>
+    <div v-if="success" class="msg-json" @click="openLink(parsedContent.jumpUrl)">
+        <p>{{ parsedContent.title }}</p>
+        <img :src="parsedContent.img" alt="">
+        <div class="bottom-bar">
+            <img :src="parsedContent.icon" alt="">
+            <span>{{ parsedContent.name }}</span>
+        </div>
+    </div>
+    <span v-else class="msg-unknown">{{
+        '( ' + $t('加载失败') + ': ' + id + ' )'
+    }}</span>
+</template>
+
+<script setup lang="ts">
+import { Logger } from '@renderer/function/base'
+import { openLink } from '@renderer/function/utils/appUtil'
+import * as z from 'zod'
+
+const { data: jsonData, id } = defineProps<{
+    data: string,
+    id: string,
+}>()
+
+const miniapp = z
+    .object({
+        app: z.literal('com.tencent.miniapp.lua'),
+        meta: z.object({
+            miniapp: z.object({
+                title: z.string(),
+                source: z.string(),
+                sourcelogo: z.url(),
+                preview: z.string(),
+                jumpUrl: z.url(),
+            }),
+        }),
+    })
+    .transform((o) => ({
+        title: o.meta.miniapp.title,
+        jumpUrl: o.meta.miniapp.jumpUrl,
+        img: o.meta.miniapp.preview,
+        icon: o.meta.miniapp.sourcelogo,
+        name: o.meta.miniapp.source,
+    }))
+
+
+const json = JSON.parse(jsonData)
+const parsedData = miniapp.safeParse(json)
+const success = parsedData.success
+const parsedContent = parsedData.data!
+if (!success) {
+    new Logger().error(parsedData.error, 'Card Parse Error')
+}
+</script>


### PR DESCRIPTION
feat: 卡片支持显示推荐机器人
fix: 无法解析无图像频道卡片

---

## 由 Sourcery 生成的摘要

支持可点击的联系人卡片，以打开外部链接，并扩展联系人解析以包含机器人卡片。

新功能：
- 新增对机器人联系人卡片的渲染和解析支持，包括头像、昵称和跳转链接（jump URL）。
- 允许联系人 JSON 卡片在点击时打开其关联的链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support clickable contact cards that can open external links and extend contact parsing to include bot cards.

New Features:
- Add support for rendering and parsing bot contact cards with avatar, nickname, and jump URL.
- Enable contact JSON cards to open their associated link when clicked.

</details>