### PR TITLE
feat: 会话历史记录

### DIFF
--- a/src/renderer/src/assets/css/view.css
+++ b/src/renderer/src/assets/css/view.css
@@ -590,6 +590,9 @@ textarea:focus {
     display: flex;
     color: var(--color-font);
 }
+.friend-list > div:first-child > div.base > svg {
+    margin: 5px;
+}
 .friend-list > div:first-child > div.base > span {
     font-weight: bold;
     flex: 1;
@@ -1931,6 +1934,45 @@ textarea:focus {
 }
 .v-leave-to > div.ss-card {
     transform: translateY(20px);
+}
+
+.history-box > .space {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 30px;
+}
+.history-box > .space > svg {
+    font-size: 50px;
+    color: var(--color-main);
+}
+
+.history-box > .main {
+    display: flex;
+    flex-direction: column;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    max-height: 60vh;
+}
+
+.history-box > .main > div {
+    display: flex;
+    align-items: center;
+    padding: 5px;
+    border-radius: 7px;
+}
+
+.history-box > .main > div:hover {
+    background-color: var(--color-card-2);
+}
+
+.history-box > .main > div > img {
+    width: 30px;
+    height: 30px;
+    object-fit: cover;
+    border-radius: 7px;
+    border: 2px solid var(--color-main);
+    margin-right: 5px;
 }
 
 @keyframes wordsLoop {

--- a/src/renderer/src/assets/l10n/zh-CN.po
+++ b/src/renderer/src/assets/l10n/zh-CN.po
@@ -1555,3 +1555,6 @@ msgstr ""
 
 msgid "自助问答"
 msgstr ""
+
+msgid "历史记录"
+msgstr ""

--- a/src/renderer/src/components/History.vue
+++ b/src/renderer/src/components/History.vue
@@ -1,0 +1,46 @@
+<template>
+    <div class="history-box">
+        <div v-if="history.record.length === 0" class="space">
+            <font-awesome-icon :icon="['fas', 'inbox']" />
+            <span>{{ $t('空空如也') }}</span>
+        </div>
+        <div v-else class="main">
+            <tiny-session-body
+                v-for="session in history.record"
+                :key="session.user_id ?? session.group_id"
+                :session="session"
+                @click="changeSession(session)" />
+        </div>
+    </div>
+</template>
+
+
+<script setup lang="ts">
+import { Session } from '@renderer/function/elements/information';
+import { runtimeData } from '@renderer/function/msg';
+import { useSessionHistoryStore } from '@renderer/state/sessionHistory';
+import { nextTick } from 'vue';
+import TinySessionBody from './TinySessionBody.vue';
+
+const history = useSessionHistoryStore()
+
+/**
+ * 切换会话
+ * @param session
+ */
+function changeSession(session: Session) {
+    const id = session.user_id ?? session.group_id
+    if (id === runtimeData.chatInfo.show.id) return
+
+    runtimeData.baseOnMsgList.set(Number(session.user_id ?? session.group_id), session)
+    // 切换到这个聊天
+    nextTick(() => {
+        const item = document.getElementById(
+            'user-' + (session.user_id ?? session.group_id),
+        )
+        if (item) {
+            item.click()
+        }
+    })
+}
+</script>

--- a/src/renderer/src/components/UmamiInfoPan.vue
+++ b/src/renderer/src/components/UmamiInfoPan.vue
@@ -150,9 +150,9 @@
                 </template>
                 <!-- 访客详情 & 事件详情 -->
                 <template v-if="showName === 'event' || showName === 'session'">
-                    <div v-show="mainListSelected != ''" v-if="eventData != null && eventData.color" class="pie-pan">
+                    <div v-show="mainListSelected != ''" v-if="eventData != null" class="pie-pan">
                         <v-chart :option="eventData" autoresize />
-                        <a>{{ $t('占比小于 {per}% 的数据将不会展示在饼图中', { per: minPiePercentage * 100 }) }}</a>
+                        <a v-if="eventData.series && eventData.series[0] && eventData.series[0].type === 'pie'">{{ $t('占比小于 {per}% 的数据将不会展示在饼图中', { per: minPiePercentage * 100 }) }}</a>
                     </div>
                     <div v-show="mainListSelected != ''" v-else>
                         <a>{{ $t('暂无数据') }}</a>
@@ -167,7 +167,7 @@
     import { defineComponent } from 'vue'
 
     import { use } from 'echarts/core'
-    import { PieChart, BarChart } from 'echarts/charts'
+    import { PieChart, BarChart, SunburstChart } from 'echarts/charts'
     import {
         LegendComponent,
         BrushComponent,
@@ -189,7 +189,8 @@
         ToolboxComponent,
         TooltipComponent,
         BarChart,
-        GridComponent
+        GridComponent,
+        SunburstChart
     ])
 
     const API_URL = import.meta.env.VITE_APP_MU_DATA_API
@@ -400,21 +401,19 @@
                         // 按 value 降序排列
                         pieData.sort((a: any, b: any) => b.value - a.value)
 
+                        const isSunburstMetric =
+                            value.indexOf('app_version') == 0 ||
+                            value.indexOf('os_version') == 0 ||
+                            value.indexOf('bot_version') == 0
+
                         // ======= 特殊处理 =======
-                        // 应用版本去除 beta- 后的部分，pre. 后的部分
-                        if (value.indexOf('app_version') == 0) {
-                            pieData = this.processAppVersion(pieData)
-                        }
-                        // 系统版本格式是：Windows 10.0.22031 (Web) 这样的，只取前两段。如果有 Web 全都归为 Web
-                        else if (value.indexOf('os_version') == 0) {
-                            pieData = this.processOsVersion(pieData)
-                        }
-                        // 机器人版本忽略版本号第三位，如果版本号前有 v 也去掉
-                        else if (value.indexOf('bot_version') == 0) {
-                            pieData = this.processBotVersion(pieData)
+                        // 应用版本、系统版本、机器人版本改为旭日图逐层展示
+                        if (isSunburstMetric) {
+                            this.eventData = this.buildSunburstOption(value, pieData, colorCard, colorFont)
+                            return
                         }
                         // 系统架构将 x86_64 统一为 x64、arm64 统一为 aarch64
-                        else if (value.indexOf('os_arch') == 0) {
+                        if (value.indexOf('os_arch') == 0) {
                             pieData = this.processOsArch(pieData)
                         }
                         // 触发按钮进行名称映射
@@ -710,6 +709,263 @@
                     }
                     return { value: item.value, name: name + ',' + version }
                 }))
+            },
+
+            buildSunburstOption(metric: string, pieData: Array<{ name: string, value: number }>, colorCard: string, colorFont: string) {
+                const sunburstData = this.getSunburstData(metric, pieData)
+                if (!sunburstData || sunburstData.length === 0) {
+                    return null
+                }
+
+                return {
+                    tooltip: {
+                        trigger: 'item',
+                        backgroundColor: colorCard,
+                        textStyle: {
+                            color: colorFont
+                        },
+                        formatter: (params: any) => {
+                            const treePath = params.treePathInfo || []
+                            const visiblePath = treePath.slice(1)
+                            const path = visiblePath.map((item: any) => item.name).join(' ')
+
+                            const toPercent = (part: number, whole: number) => {
+                                if (!whole || whole <= 0) return '0.00%'
+                                return `${((part / whole) * 100).toFixed(2)}%`
+                            }
+
+                            const rootValue = Number(treePath[0]?.value || params.value || 0)
+                            const levelLines = visiblePath.map((node: any, index: number) => {
+                                const currentValue = Number(node.value || 0)
+                                const parentValue = Number(treePath[index]?.value || rootValue)
+                                const parentPercent = toPercent(currentValue, parentValue)
+                                const totalPercent = toPercent(currentValue, rootValue)
+                                return `${node.name}: ${parentPercent} (${this.$t('全局')} ${totalPercent})`
+                            })
+
+                            return `${params.marker} ${path}<br/>${this.$t('数值')}: ${params.value}<br/>${levelLines.join('<br/>')}`
+                        }
+                    },
+                    series: [
+                        {
+                            type: 'sunburst',
+                            radius: ['20%', '90%'],
+                            itemStyle: {
+                                borderWidth: 3,
+                                borderRadius: 7,
+                                borderColor: colorCard
+                            },
+                            label: {
+                                show: false
+                            },
+                            emphasis: {
+                                focus: 'series'
+                            },
+                            data: sunburstData
+                        }
+                    ]
+                }
+            },
+
+            getSunburstData(metric: string, pieData: Array<{ name: string, value: number }>) {
+                if (metric.indexOf('os_version') == 0) {
+                    return this.buildOsVersionSunburstData(pieData)
+                }
+                if (metric.indexOf('app_version') == 0) {
+                    return this.buildVersionSunburstData(pieData, 'app')
+                }
+                if (metric.indexOf('bot_version') == 0) {
+                    return this.buildVersionSunburstData(pieData, 'bot')
+                }
+                return []
+            },
+
+            buildOsVersionSunburstData(pieData: Array<{ name: string, value: number }>) {
+                const tree: Record<string, Record<string, number>> = {}
+                const appleSystems = new Set(['macOS', 'iPadOS', 'iOS'])
+
+                for (const item of pieData) {
+                    const parsed = this.parseOsVersionNode(item.name)
+                    const rawSystemName = parsed.systemName
+                    const systemName = appleSystems.has(rawSystemName) ? `apple/${rawSystemName}` : rawSystemName
+                    const version = parsed.version
+
+                    if (!tree[systemName]) {
+                        tree[systemName] = {}
+                    }
+                    tree[systemName][version] = (tree[systemName][version] || 0) + item.value
+                }
+
+                const result: Array<{ name: string, children: any[] }> = []
+                const appleChildren: Array<{ name: string, children: any[] }> = []
+
+                for (const systemName of Object.keys(tree)) {
+                    const children = Object.keys(tree[systemName]).map(version => ({
+                        name: version,
+                        value: tree[systemName][version]
+                    }))
+                    children.sort((a, b) => b.value - a.value)
+
+                    if (systemName.startsWith('apple/')) {
+                        appleChildren.push({
+                            name: systemName.replace('apple/', ''),
+                            children
+                        })
+                    } else {
+                        result.push({
+                            name: systemName,
+                            children
+                        })
+                    }
+                }
+
+                if (appleChildren.length > 0) {
+                    appleChildren.sort((a, b) => {
+                        const aValue = a.children.reduce((sum, child) => sum + child.value, 0)
+                        const bValue = b.children.reduce((sum, child) => sum + child.value, 0)
+                        return bValue - aValue
+                    })
+                    result.push({
+                        name: 'apple',
+                        children: appleChildren
+                    })
+                }
+
+                result.sort((a, b) => {
+                    const aValue = a.children.reduce((sum, child) => sum + child.value, 0)
+                    const bValue = b.children.reduce((sum, child) => sum + child.value, 0)
+                    return bValue - aValue
+                })
+                return result
+            },
+
+            buildVersionSunburstData(pieData: Array<{ name: string, value: number }>, type: 'app' | 'bot') {
+                const tree: Record<string, Record<string, Record<string, number>>> = {}
+
+                for (const item of pieData) {
+                    let parsed
+                    if (type === 'app') {
+                        parsed = this.parseAppVersionNode(item.name)
+                    } else {
+                        parsed = this.parseBotVersionNode(item.name)
+                    }
+
+                    const branch = parsed.branch
+                    const majorMinor = parsed.majorMinor
+                    const detail = parsed.detail
+
+                    if (!tree[branch]) {
+                        tree[branch] = {}
+                    }
+                    if (!tree[branch][majorMinor]) {
+                        tree[branch][majorMinor] = {}
+                    }
+                    tree[branch][majorMinor][detail] = (tree[branch][majorMinor][detail] || 0) + item.value
+                }
+
+                const result = Object.keys(tree).map(branch => ({
+                    name: branch,
+                    children: Object.keys(tree[branch]).map(majorMinor => ({
+                        name: majorMinor,
+                        children: Object.keys(tree[branch][majorMinor]).map(detail => ({
+                            name: detail,
+                            value: tree[branch][majorMinor][detail]
+                        })).sort((a, b) => b.value - a.value)
+                    }))
+                }))
+
+                result.sort((a, b) => {
+                    const sumNode = (node: any): number => {
+                        if (node.value) return node.value
+                        if (!node.children) return 0
+                        return node.children.reduce((sum: number, child: any) => sum + sumNode(child), 0)
+                    }
+                    return sumNode(b) - sumNode(a)
+                })
+
+                return result
+            },
+
+            parseOsVersionNode(rawName: string) {
+                const raw = (rawName || '').trim()
+                if (!raw) {
+                    return {
+                        systemName: this.$t('未知'),
+                        version: this.$t('未知')
+                    }
+                }
+
+                if (raw.includes('(Web)')) {
+                    return {
+                        systemName: 'Web',
+                        version: 'Web'
+                    }
+                }
+
+                const parts = raw.split(/\s+/)
+                if (parts.length >= 2) {
+                    return {
+                        systemName: parts[0],
+                        version: parts[1]
+                    }
+                }
+
+                return {
+                    systemName: raw,
+                    version: this.$t('未知')
+                }
+            },
+
+            parseAppVersionNode(rawName: string) {
+                const raw = (rawName || '').trim()
+                const segs = raw.split(',').map(seg => seg.trim()).filter(Boolean)
+                const versionRaw = segs[1] || ''
+                const versionLower = versionRaw.toLowerCase()
+                const branchRaw = segs[0] || this.$t('未知')
+                const branch = versionLower.includes('pre') ? 'pre' : branchRaw
+                const versionInfo = this.extractVersionGroups(versionRaw)
+                return {
+                    branch,
+                    majorMinor: versionInfo.majorMinor,
+                    detail: versionInfo.detail
+                }
+            },
+
+            parseBotVersionNode(rawName: string) {
+                const raw = (rawName || '').trim()
+                const segs = raw.split(',').map(seg => seg.trim()).filter(Boolean)
+                const branch = segs[0] || this.$t('未知')
+                const versionRaw = segs[1] || segs[0] || ''
+                const versionInfo = this.extractVersionGroups(versionRaw)
+                return {
+                    branch,
+                    majorMinor: versionInfo.majorMinor,
+                    detail: versionInfo.detail
+                }
+            },
+
+            extractVersionGroups(rawVersion: string) {
+                const cleaned = (rawVersion || '').replace(/^v/i, '')
+                const matched = cleaned.match(/(\d+)(?:\.(\d+))?(?:\.(\d+))?(.*)?/) || []
+
+                if (!matched[1]) {
+                    const unknown = this.$t('未知')
+                    return {
+                        majorMinor: unknown,
+                        detail: unknown
+                    }
+                }
+
+                const major = matched[1]
+                const minorNum = matched[2] || '0'
+                const patchNum = matched[3] || '0'
+                const suffix = (matched[4] || '').trim()
+                const detail = `${patchNum}${suffix}`
+
+                return {
+                    majorMinor: `${major}.${minorNum}`,
+                    detail
+                }
             },
 
             /**

--- a/src/renderer/src/function/elements/information.ts
+++ b/src/renderer/src/function/elements/information.ts
@@ -7,7 +7,7 @@ export enum BotMsgType {
 }
 
 export interface RunTimeDataElem {
-    sysConfig: Record<keyof typeof optDefault, any|null>
+    sysConfig: Record<keyof typeof optDefault, any | null>
     jsonMap?: any
     botInfo: { [key: string]: any }
     loginInfo: { [key: string]: any }
@@ -28,7 +28,7 @@ export interface RunTimeDataElem {
         msgType: BotMsgType
         nowGetHistory: boolean
         canLoadHistory: boolean
-		loadHistoryFail: boolean
+        loadHistoryFail: boolean
         openSideBar: boolean
         loginWaveTimer?: any
         connectSsl: boolean
@@ -43,7 +43,7 @@ export interface RunTimeDataElem {
         lastHeartbeatTime?: number
         backTimes: number
     }
-	inch: number
+    inch: number
     messageList: any[]
     mergeMsgStack: MergeStackData[]
     mergeMessageList?: any[] | undefined
@@ -176,7 +176,7 @@ export interface MsgItemElem {
     [key: string]: any
 }
 
-export interface MergeStackData{
+export interface MergeStackData {
     messageList: any[]      // 消息列表
     imageList: any[]        // 图片列表
     placeCache: number      // 位置缓存
@@ -188,3 +188,5 @@ export interface MenuEventData {
     y: number
     target: HTMLElement
 }
+
+export type Session = UserGroupElem & UserFriendElem

--- a/src/renderer/src/pages/Chat.vue
+++ b/src/renderer/src/pages/Chat.vue
@@ -597,6 +597,7 @@ import { dbGetBefore, dbSearchMessages } from '@renderer/function/utils/localHis
 import Emoji from '@renderer/function/model/emoji'
 import EmojiFace from '@renderer/components/EmojiFace.vue'
 import { Img } from '@renderer/function/model/img'
+import { useSessionHistoryStore } from '@renderer/state/sessionHistory'
 </script>
 
 <script lang="ts">
@@ -754,6 +755,11 @@ import { Img } from '@renderer/function/model/img'
                 this.$nextTick(() => {
                     this.resizeMainInput()
                 })
+                // 记录历史
+                const history = useSessionHistoryStore()
+                const sessionId = this.chat.show.id
+                const session = [...runtimeData.userList].find(i => (i.user_id ?? i.group_id) === sessionId)
+                if (session) history.add(session)
             },
             msg(newMsg: string, oldMsg: string) {
                 this.oldMsg = oldMsg
@@ -765,6 +771,12 @@ import { Img } from '@renderer/function/model/img'
             }
         },
         async mounted() {
+            // 记录历史
+            const history = useSessionHistoryStore()
+            const sessionId = this.chat.show.id
+            const session = [...runtimeData.userList].find(i => (i.user_id ?? i.group_id) === sessionId)
+            if (session) history.add(session)
+
             // 消息列表刷新
             this.updateList(this.list.length, 0)
             // PS：由于监听 list 本身返回的新旧值是一样，于是监听 length（反正也只要知道长度）

--- a/src/renderer/src/pages/Messages.vue
+++ b/src/renderer/src/pages/Messages.vue
@@ -20,6 +20,10 @@
                     <div class="base only">
                         <span>{{ $t('消息') }}</span>
                         <div style="flex: 1" />
+                        <font-awesome-icon
+                    :icon="['fas', 'clock-rotate-left']"
+                    @click="openHistory"
+                />
                         <font-awesome-icon :icon="['fas', 'trash-can']" @click="cleanList" />
                     </div>
                     <div class="small">
@@ -188,7 +192,7 @@
     import Menu from 'vue3-bcui/packages/bc-menu/index'
     import Option from '@renderer/function/option'
 
-    import { defineComponent } from 'vue'
+    import { defineComponent, markRaw } from 'vue'
     import { runtimeData } from '@renderer/function/msg'
     import {
         UserFriendElem,
@@ -212,6 +216,7 @@
     import { Notify } from '@renderer/function/notify'
     import { refreshFavicon } from '@renderer/function/favicon'
     import { backend } from '@renderer/runtime/backend'
+import History from '@renderer/components/History.vue'
 
     export default defineComponent({
         name: 'VueMessages',
@@ -593,6 +598,15 @@
             },
             showMenuEnd() {
                 this.showMenu = false
+            },
+
+            openHistory() {
+                const popInfo = {
+                    template: markRaw(History),
+                    svg: 'clock-rotate-left',
+                    title: app.config.globalProperties.$t('历史记录')
+                }
+                runtimeData.popBoxList.push(popInfo)
             },
         },
     })

--- a/src/renderer/src/state/sessionHistory.ts
+++ b/src/renderer/src/state/sessionHistory.ts
@@ -1,0 +1,25 @@
+import { Session } from '@renderer/function/elements/information'
+import { defineStore } from 'pinia'
+import { shallowRef } from 'vue'
+
+const MAX_LENGTH = 50
+
+export const useSessionHistoryStore = defineStore('session-history', () => {
+    const record = shallowRef<Session[]>([])
+
+    function add(session: Session) {
+        record.value = [
+            session,
+            ...record.value.filter((i) => (i.user_id !== session.user_id) || (i.group_id !== session.group_id)),
+        ]
+        if (record.value.length > MAX_LENGTH) {
+            record.value.pop()
+            record.value = [...record.value]
+        }
+    }
+
+    return {
+        record,
+        add,
+    }
+})


### PR DESCRIPTION
<img width="514" height="674" alt="图片" src="https://github.com/user-attachments/assets/190e3cc4-0d62-4913-80e1-fc47e8069a0d" />

## Summary by Sourcery

添加会话历史功能，用于跟踪最近打开的聊天，并在消息视图中通过新的历史面板进行展示。

New Features:
- 引入一个 Pinia store，用于维护一个有上限大小的最近访问聊天会话列表。
- 新增一个历史弹出组件，在消息视图中列出最近的会话，并允许快速切换回这些会话。

Enhancements:
- 为新的历史面板添加样式，并调整好友列表图标间距，以保持布局一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a session history feature that tracks recently opened chats and exposes them via a new history panel in the messages view.

New Features:
- Introduce a Pinia store to maintain a bounded list of recently accessed chat sessions.
- Add a history pop-up component that lists recent sessions and allows quickly switching back to them from the messages view.

Enhancements:
- Style the new history panel and adjust friend list icon spacing for consistent layout.

</details>