### PR TITLE
feat: add option to show all sessions

### DIFF
--- a/src/renderer/src/components/FriendBody.vue
+++ b/src/renderer/src/components/FriendBody.vue
@@ -21,13 +21,7 @@
             <div>
                 <p>{{ getShowName(data.group_name || data.nickname, data.remark) }}</p>
                 <div style="flex: 1" />
-                <a class="time">{{
-                    data.time !== undefined
-                        ? Intl.DateTimeFormat(trueLang, {
-                            hour: 'numeric',
-                            minute: 'numeric',
-                        }).format(new Date(data.time)) : ''
-                }}</a>
+                <a class="time">{{ formatSessionTime(data.time) }}</a>
             </div>
             <div>
                 <a v-if="data.highlight" class="highlight">
@@ -58,4 +52,30 @@ defineProps<{
 }>()
 
 const trueLang = getTrueLang()
+
+function isSameDate(a: Date, b: Date) {
+    return a.getFullYear() === b.getFullYear() &&
+        a.getMonth() === b.getMonth() &&
+        a.getDate() === b.getDate()
+}
+
+function formatSessionTime(time: number | undefined) {
+    if (time === undefined) return ''
+
+    const date = new Date(time)
+    if (Number.isNaN(date.getTime())) return ''
+
+    if (isSameDate(date, new Date())) {
+        return Intl.DateTimeFormat(trueLang, {
+            hour: 'numeric',
+            minute: 'numeric',
+        }).format(date)
+    }
+
+    return Intl.DateTimeFormat(trueLang, {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+    }).format(date)
+}
 </script>

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -23,6 +23,8 @@ import {
     getMsgData,
     parseMsgList,
     getMsgRawTxt,
+    addAllSessionsToBaseOnMsgList,
+    updateBaseOnMsgList,
     updateLastestHistory,
     sendMsgAppendInfo,
 } from '@renderer/function/utils/msgUtil'
@@ -1401,6 +1403,10 @@ function saveUser(msg: { [key: string]: any }, type: string) {
                     }
                 })
             }
+        }
+        if (settingsStore.sysConfig.show_all_sessions === true) {
+            addAllSessionsToBaseOnMsgList(list)
+            updateBaseOnMsgList()
         }
         // 更新菜单
         updateMenu({

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -23,7 +23,6 @@ import {
     getMsgData,
     parseMsgList,
     getMsgRawTxt,
-    addAllSessionsToBaseOnMsgList,
     updateBaseOnMsgList,
     updateLastestHistory,
     sendMsgAppendInfo,
@@ -1404,10 +1403,7 @@ function saveUser(msg: { [key: string]: any }, type: string) {
                 })
             }
         }
-        if (settingsStore.sysConfig.show_all_sessions === true) {
-            addAllSessionsToBaseOnMsgList(list)
-            updateBaseOnMsgList()
-        }
+        updateBaseOnMsgList()
         // 更新菜单
         updateMenu({
             parent: 'account',

--- a/src/renderer/src/function/option.ts
+++ b/src/renderer/src/function/option.ts
@@ -102,6 +102,7 @@ export const optDefault: { [key: string]: any } = {
     // Function
     close_notice: false,
     bubble_sort_user: true,
+    show_all_sessions: false,
     close_respond: false,
     msg_taill: '',
     quick_send: 'default',
@@ -151,6 +152,7 @@ const configFunction: { [key: string]: (value: any) => void } = {
     opt_always_top: viewAlwaysTop,
     opt_fast_animation: updateFarstAnimation,
     bubble_sort_user: clearGroupAssist,
+    show_all_sessions: clearGroupAssist,
     use_favicon_notice: setFaviconNotice,
     custom_css: injectCustomCss,
     opt_ind_message: updateChatPan

--- a/src/renderer/src/function/utils/msgUtil.ts
+++ b/src/renderer/src/function/utils/msgUtil.ts
@@ -553,12 +553,31 @@ export function updateLastestHistory(item: UserFriendElem & UserGroupElem) {
     )
 }
 
+export function addAllSessionsToBaseOnMsgList(list: (UserFriendElem & UserGroupElem)[]) {
+    const contactStore = useContactStore()
+    list.forEach((item) => {
+        const id = Number(item.user_id ?? item.group_id)
+        if (!Number.isFinite(id) || id <= 0) return
+        if (contactStore.baseOnMsgList.has(id)) return
+
+        contactStore.baseOnMsgList.set(id, {
+            ...item,
+            raw_msg: item.raw_msg ?? '',
+            raw_msg_base: item.raw_msg_base ?? '',
+            time: item.time ?? 0
+        })
+    })
+}
+
 /**
  * 刷新消息列表排序
  */
 export function updateBaseOnMsgList() {
     const contactStore = useContactStore()
     const settingsStore = useSettingsStore()
+    if (settingsStore.sysConfig.show_all_sessions === true) {
+        addAllSessionsToBaseOnMsgList(contactStore.userList)
+    }
     const allList = [...contactStore.baseOnMsgList.values()]
     // 先更具 item.always_top 是不是 true 拆为两个数组
     const topList = allList.filter((item) => item.always_top)
@@ -578,12 +597,30 @@ export function updateBaseOnMsgList() {
         }
         return b.time - a.time
     }
-    topList.sort(sortFun)
-    normalList.sort(sortFun)
+    const sortAllSessionsFun = (
+        a: UserFriendElem & UserGroupElem,
+        b: UserFriendElem & UserGroupElem,
+    ) => {
+        const timeA = Number(a.time ?? 0)
+        const timeB = Number(b.time ?? 0)
+        if (timeA !== timeB) return timeB - timeA
+
+        const pyA = a.py_start ?? ''
+        const pyB = b.py_start ?? ''
+        if (pyA !== pyB) return pyA.localeCompare(pyB)
+
+        const nameA = getShowName(a.group_name ?? a.nickname ?? '', a.remark ?? '')
+        const nameB = getShowName(b.group_name ?? b.nickname ?? '', b.remark ?? '')
+        return nameA.localeCompare(nameB)
+    }
+    topList.sort(settingsStore.sysConfig.show_all_sessions === true ? sortAllSessionsFun : sortFun)
+    normalList.sort(settingsStore.sysConfig.show_all_sessions === true ? sortAllSessionsFun : sortFun)
 
     let onMsgList = [] as any[]
     let groupAssistList = [] as any[]
-    if (settingsStore.sysConfig.bubble_sort_user) {
+    if (settingsStore.sysConfig.show_all_sessions === true) {
+        onMsgList = topList.concat(normalList)
+    } else if (settingsStore.sysConfig.bubble_sort_user) {
         // 将 normalList 进行拆分
         onMsgList = topList.concat(normalList.filter((item) => {
             return item.group_id && canGroupNotice(item.group_id) ||

--- a/src/renderer/src/function/utils/msgUtil.ts
+++ b/src/renderer/src/function/utils/msgUtil.ts
@@ -618,9 +618,7 @@ export function updateBaseOnMsgList() {
 
     let onMsgList = [] as any[]
     let groupAssistList = [] as any[]
-    if (settingsStore.sysConfig.show_all_sessions === true) {
-        onMsgList = topList.concat(normalList)
-    } else if (settingsStore.sysConfig.bubble_sort_user) {
+    if (settingsStore.sysConfig.bubble_sort_user) {
         // 将 normalList 进行拆分
         onMsgList = topList.concat(normalList.filter((item) => {
             return item.group_id && canGroupNotice(item.group_id) ||

--- a/src/renderer/src/function/utils/msgUtil.ts
+++ b/src/renderer/src/function/utils/msgUtil.ts
@@ -553,6 +553,15 @@ export function updateLastestHistory(item: UserFriendElem & UserGroupElem) {
     )
 }
 
+function getSessionTime(item: UserFriendElem & UserGroupElem) {
+    const time = Number(item.time ?? 0)
+    return Number.isFinite(time) ? time : 0
+}
+
+function getSessionSortName(item: UserFriendElem & UserGroupElem) {
+    return item.py_start ?? getShowName(item.group_name ?? item.nickname ?? '', item.remark ?? '')
+}
+
 export function addAllSessionsToBaseOnMsgList(list: (UserFriendElem & UserGroupElem)[]) {
     const contactStore = useContactStore()
     list.forEach((item) => {
@@ -560,12 +569,18 @@ export function addAllSessionsToBaseOnMsgList(list: (UserFriendElem & UserGroupE
         if (!Number.isFinite(id) || id <= 0) return
         if (contactStore.baseOnMsgList.has(id)) return
 
-        contactStore.baseOnMsgList.set(id, {
+        const session = {
             ...item,
             raw_msg: item.raw_msg ?? '',
             raw_msg_base: item.raw_msg_base ?? '',
-            time: item.time ?? 0
-        })
+        } as UserFriendElem & UserGroupElem
+        if (item.time !== undefined) {
+            session.time = item.time
+        }
+        contactStore.baseOnMsgList.set(id, session)
+        if (session.time === undefined && !session.raw_msg) {
+            updateLastestHistory(session)
+        }
     })
 }
 
@@ -575,7 +590,8 @@ export function addAllSessionsToBaseOnMsgList(list: (UserFriendElem & UserGroupE
 export function updateBaseOnMsgList() {
     const contactStore = useContactStore()
     const settingsStore = useSettingsStore()
-    if (settingsStore.sysConfig.show_all_sessions === true) {
+    const showAll = settingsStore.sysConfig.show_all_sessions === true
+    if (showAll) {
         addAllSessionsToBaseOnMsgList(contactStore.userList)
     }
     const allList = [...contactStore.baseOnMsgList.values()]
@@ -601,20 +617,14 @@ export function updateBaseOnMsgList() {
         a: UserFriendElem & UserGroupElem,
         b: UserFriendElem & UserGroupElem,
     ) => {
-        const timeA = Number(a.time ?? 0)
-        const timeB = Number(b.time ?? 0)
+        const timeA = getSessionTime(a)
+        const timeB = getSessionTime(b)
         if (timeA !== timeB) return timeB - timeA
 
-        const pyA = a.py_start ?? ''
-        const pyB = b.py_start ?? ''
-        if (pyA !== pyB) return pyA.localeCompare(pyB)
-
-        const nameA = getShowName(a.group_name ?? a.nickname ?? '', a.remark ?? '')
-        const nameB = getShowName(b.group_name ?? b.nickname ?? '', b.remark ?? '')
-        return nameA.localeCompare(nameB)
+        return getSessionSortName(a).localeCompare(getSessionSortName(b))
     }
-    topList.sort(settingsStore.sysConfig.show_all_sessions === true ? sortAllSessionsFun : sortFun)
-    normalList.sort(settingsStore.sysConfig.show_all_sessions === true ? sortAllSessionsFun : sortFun)
+    topList.sort(showAll ? sortAllSessionsFun : sortFun)
+    normalList.sort(showAll ? sortAllSessionsFun : sortFun)
 
     let onMsgList = [] as any[]
     let groupAssistList = [] as any[]

--- a/src/renderer/src/pages/options/OptFunction.vue
+++ b/src/renderer/src/pages/options/OptFunction.vue
@@ -40,6 +40,21 @@
                     </div>
                 </label>
             </div>
+            <div class="opt-item">
+                <div :class="checkDefault('show_all_sessions')" />
+                <font-awesome-icon :icon="['fas', 'address-book']" />
+                <div>
+                    <span>{{ $t('显示全部会话') }}</span>
+                    <span>{{ $t('在消息页显示全部好友和群；未开启时仍按最近会话和群收纳盒逻辑显示') }}</span>
+                </div>
+                <label class="ss-switch">
+                    <input v-model="settingsStore.sysConfig.show_all_sessions"
+                        type="checkbox" name="show_all_sessions" @change="save">
+                    <div>
+                        <div />
+                    </div>
+                </label>
+            </div>
             <div v-if="!settingsStore.sysConfig.bubble_sort_user" class="opt-item">
                 <div :class="checkDefault('group_notice_type')" />
                 <font-awesome-icon :icon="['fas', 'user-group']" />


### PR DESCRIPTION
## Summary

This PR adds an optional setting to show all loaded friends and groups in the message page.

The option is disabled by default, so existing users keep the current recent-session behavior unless they explicitly enable it.

## Motivation

In some Web/Docker + NapCat deployments, `get_recent_contact` may return only a small subset of recent conversations after a page refresh. The full friend/group list is already loaded in `contactStore.userList`, and those contacts can still be found through search, but they may not appear in the message page.

This option lets users show all loaded sessions while still preserving the existing group-assist behavior.

## Changes

- Add a new disabled-by-default `show_all_sessions` option.
- Add a settings switch labeled `显示全部会话` in the function options page.
- When the option is enabled, loaded friends/groups are added to `contactStore.baseOnMsgList` without overwriting existing recent-message state.
- Preserve existing pinned-session behavior.
- Sort sessions with message time above sessions without message time.
- Keep group-assist routing intact:
  - if group assist is enabled, group-assist groups still stay in group assist;
  - if group assist is disabled, all sessions are shown in the main message list.

## Compatibility

- Default behavior remains unchanged because the new option defaults to `false`.
- Existing group-assist behavior remains unchanged when group assist is enabled.
- No OneBot/NapCat API changes are required.

## Testing

- [x] `corepack yarn lint`
- [x] `corepack yarn typecheck`
- [x] `corepack yarn build`
- [x] Built and deployed a Docker image from the combined branch for runtime smoke testing

Manual UI checks for every group-assist combination were not automated in this environment.

## Summary by Sourcery

在保留现有最近会话和群助手行为的前提下，新增一个可选设置，用于在消息页面显示所有已加载的好友和群聊会话。

新功能：
- 引入一个默认禁用的 `show_all_sessions` 配置选项，用于控制消息列表中是否显示所有已加载的好友和群聊。
- 在功能选项页面中提供一个新的开关，用于启用或禁用“显示所有会话”。
- 在好友列表中显示会话时间戳，使用一个辅助函数：对于当天的会话显示具体时间，对于较早的会话显示完整日期。

增强内容：
- 当启用新选项时，从完整联系人列表填充 `baseOnMsgList`，并且不覆盖现有的最近消息状态。
- 调整消息列表排序规则，使会话按消息时间排序；当时间相同时稳定地回退到按名称排序，并确保在保存用户数据后再执行更新。
- 当新选项发生变化时复用群助手的清理逻辑，以保持消息路由与现有行为一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an optional setting to show all loaded friend and group sessions on the message page while preserving existing recent-session and group-assist behavior.

New Features:
- Introduce a disabled-by-default show_all_sessions configuration option to control whether all loaded friends and groups are shown in the message list.
- Expose a new toggle in the function options page to enable or disable displaying all sessions.
- Display session timestamps in the friend list using a helper that formats either time-of-day for today or a full date for older sessions.

Enhancements:
- Populate the baseOnMsgList from the full contact list when the new option is enabled, without overwriting existing recent-message state.
- Adjust message list sorting so sessions are ordered by message time with a consistent fallback to name-based sorting when times are equal, and ensure updates run after saving user data.
- Reuse group-assist clearing logic when the new option changes to keep message routing consistent with existing behavior.

</details>

新功能：
- 引入一个默认关闭的 `show_all_sessions` 设置项，用于控制是否在消息页面显示所有已加载的好友和群组。
- 在功能设置界面中增加对 `show_all_sessions` 选项的开关。

增强：
- 确保无消息的会话也会被包含在内，同时不覆盖现有的最近消息状态；将这些会话排在有消息时间戳的会话之后，当时间相同时回退为按名称排序。
- 更新消息列表的构建逻辑，在启用新选项时合并完整联系人列表，并保持群助手的路由逻辑与现有行为一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保留现有最近会话和群助手行为的前提下，新增一个可选设置，用于在消息页面显示所有已加载的好友和群聊会话。

新功能：
- 引入一个默认禁用的 `show_all_sessions` 配置选项，用于控制消息列表中是否显示所有已加载的好友和群聊。
- 在功能选项页面中提供一个新的开关，用于启用或禁用“显示所有会话”。
- 在好友列表中显示会话时间戳，使用一个辅助函数：对于当天的会话显示具体时间，对于较早的会话显示完整日期。

增强内容：
- 当启用新选项时，从完整联系人列表填充 `baseOnMsgList`，并且不覆盖现有的最近消息状态。
- 调整消息列表排序规则，使会话按消息时间排序；当时间相同时稳定地回退到按名称排序，并确保在保存用户数据后再执行更新。
- 当新选项发生变化时复用群助手的清理逻辑，以保持消息路由与现有行为一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an optional setting to show all loaded friend and group sessions on the message page while preserving existing recent-session and group-assist behavior.

New Features:
- Introduce a disabled-by-default show_all_sessions configuration option to control whether all loaded friends and groups are shown in the message list.
- Expose a new toggle in the function options page to enable or disable displaying all sessions.
- Display session timestamps in the friend list using a helper that formats either time-of-day for today or a full date for older sessions.

Enhancements:
- Populate the baseOnMsgList from the full contact list when the new option is enabled, without overwriting existing recent-message state.
- Adjust message list sorting so sessions are ordered by message time with a consistent fallback to name-based sorting when times are equal, and ensure updates run after saving user data.
- Reuse group-assist clearing logic when the new option changes to keep message routing consistent with existing behavior.

</details>

</details>