### PR TITLE
feat:支持语音消息

### DIFF
--- a/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
+++ b/src/renderer/src/assets/pathMap/Lagrange.OneBot.yaml
@@ -172,3 +172,9 @@ send_respond:
 # 撤回消息
 delete_msg:
     name: delete_msg
+# 获取语音消息文件
+get_record:
+    name: get_record
+    file: $..file
+    url: $..url
+    base64: $..base64

--- a/src/renderer/src/assets/pathMap/NapCat.Onebot.yaml
+++ b/src/renderer/src/assets/pathMap/NapCat.Onebot.yaml
@@ -216,3 +216,9 @@ ban_mumber:
 # 撤回消息
 delete_msg:
     name: delete_msg
+# 获取语音消息文件
+get_record:
+    name: get_record
+    file: $..file
+    url: $..url
+    base64: $..base64

--- a/src/renderer/src/components/MsgBody.vue
+++ b/src/renderer/src/components/MsgBody.vue
@@ -186,6 +186,12 @@
                                 现在还有不支持 video tag 的浏览器吗？
                             </video>
                         </div>
+                        <template v-else-if="item.type == 'record'">
+                            <VoiceMsg
+                                :item="item"
+                                :message-id="String(data.message_id)"
+                                :is-me="isMe" />
+                        </template>
                         <template v-else-if="item.type == 'forward'">
                             <div class="msg-raw-forward"
                                 @click="openMerge()">
@@ -211,6 +217,9 @@
                                                 </span>
                                                 <span v-else-if="msg.type == 'video'">
                                                     [{{ $t('视频') }}]
+                                                </span>
+                                                <span v-else-if="msg.type == 'record'">
+                                                    [{{ $t('语音') }}]
                                                 </span>
                                                 <span v-else-if="msg.type == 'forward'">
                                                     [{{ $t('聊天记录') }}]
@@ -419,6 +428,7 @@ import { Img } from '@renderer/function/model/img'
 import { dbGetImage, hashUrl } from '@renderer/function/utils/localHistoryUtil'
 import JsonSegComp from './msg-component/JsonSegComp.vue'
 import XmlSegComp from './msg-component/XmlSegComp.vue'
+import VoiceMsg from './VoiceMsg.vue'
 import { addMusic, MusicInfo } from './MusicPlayer.vue'
 
 type Msg = any

--- a/src/renderer/src/components/VoiceMsg.vue
+++ b/src/renderer/src/components/VoiceMsg.vue
@@ -237,6 +237,8 @@ onBeforeUnmount(() => {
         audio.pause()
         audio.src = ''
     }
+    // 释放缓存的 blob URL
+    revokeRecord(props.messageId)
 })
 </script>
 

--- a/src/renderer/src/components/VoiceMsg.vue
+++ b/src/renderer/src/components/VoiceMsg.vue
@@ -1,0 +1,343 @@
+<!--
+ * @FileDescription: 语音消息组件
+ * @Description: 渲染 QQ 语音消息，支持播放/暂停、进度显示和时长展示。
+ *   语音消息通过 recordUtil 调用 OneBot get_record API 加载。
+ *   如果协议端不支持格式转换，显示"不支持的消息"。
+-->
+
+<template>
+    <div class="voice-msg"
+        :class="{ me: isMe, loading: isLoading, playing: isPlaying }"
+        :style="bubbleStyle"
+        @click.stop="togglePlay">
+        <!-- 播放/加载图标 -->
+        <div class="voice-icon">
+            <font-awesome-icon v-if="isLoading" :icon="['fas', 'spinner']" spin />
+            <font-awesome-icon v-else-if="isError" :icon="['fas', 'exclamation-circle']" />
+            <font-awesome-icon v-else-if="isPlaying" :icon="['fas', 'pause']" />
+            <font-awesome-icon v-else :icon="['fas', 'play']" />
+        </div>
+
+        <!-- 进度条区域 -->
+        <div class="voice-progress">
+            <template v-if="isUnsupported">
+                <span class="voice-unsupported">{{ $t('不支持的消息') }}</span>
+            </template>
+            <template v-else>
+                <div class="voice-bar-bg">
+                    <div class="voice-bar-fill" :style="{ width: progressPercent + '%' }" />
+                </div>
+                <span class="voice-duration">
+                    {{ isError ? $t('加载失败') : formatTime }}
+                </span>
+            </template>
+        </div>
+
+        <!-- 音频元素，仅在有可用 src 时渲染 -->
+        <audio v-if="audioSrc"
+            ref="audioRef"
+            :src="audioSrc"
+            preload="auto"
+            @loadedmetadata="onLoaded"
+            @error="onError"
+            @timeupdate="onTimeUpdate"
+            @ended="onEnded"
+            @play="isPlaying = true"
+            @pause="isPlaying = false" />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onBeforeUnmount, onMounted } from 'vue'
+import { loadRecord, revokeRecord, formatRecordDuration, type RecordMsgData } from '@renderer/function/utils/recordUtil'
+import { Logger } from '@renderer/function/base'
+
+const logger = new Logger()
+
+// ============================================================================
+// Props
+// ============================================================================
+
+const props = defineProps<{
+    /** 语音消息数据 */
+    item: RecordMsgData
+    /** 消息 ID（用于缓存） */
+    messageId?: string
+    /** 是否为本人发送的消息 */
+    isMe?: boolean
+}>()
+
+// ============================================================================
+// 响应式状态
+// ============================================================================
+
+const audioRef = ref<HTMLAudioElement | null>(null)
+const audioSrc = ref<string>('')
+const isLoading = ref(false)
+const isError = ref(false)
+const isUnsupported = ref(false)
+const isPlaying = ref(false)
+const currentTime = ref(0)
+const duration = ref(props.item.duration || 0)
+const loaded = ref(false)
+
+// ============================================================================
+// 计算属性
+// ============================================================================
+
+const progressPercent = computed(() => {
+    if (duration.value <= 0) return 0
+    return Math.min(100, (currentTime.value / duration.value) * 100)
+})
+
+const formatTime = computed(() => {
+    if (isLoading.value) return '--:--'
+    if (isError.value) return '⚠'
+    if (isUnsupported.value) return ''
+    if (!loaded.value && duration.value <= 0) return '--:--'
+    if (isPlaying.value || currentTime.value > 0) {
+        return formatRecordDuration(currentTime.value)
+    }
+    return formatRecordDuration(duration.value)
+})
+
+/**
+ * 根据语音时长计算气泡宽度
+ * 模仿 QQ 语音消息样式：时长越长，气泡越宽
+ * 范围：120px (最短) ~ 260px (最长，上限 60 秒)
+ */
+const bubbleStyle = computed(() => {
+    const dur = duration.value || 1
+    const minWidth = 120
+    const maxWidth = 260
+    const width = Math.min(maxWidth, Math.max(minWidth, minWidth + (dur / 60) * (maxWidth - minWidth)))
+    return {
+        width: `${Math.round(width)}px`,
+    }
+})
+
+// ============================================================================
+// 方法
+// ============================================================================
+
+/**
+ * 加载语音资源
+ */
+async function loadVoice() {
+    if (loaded.value || isLoading.value) return
+
+    isLoading.value = true
+    isError.value = false
+    isUnsupported.value = false
+
+    try {
+        const result = await loadRecord(props.item, props.messageId)
+        audioSrc.value = result.src
+        duration.value = result.duration || props.item.duration || 0
+        loaded.value = true
+
+        logger.debug(`语音加载完成: 时长=${duration.value}s`)
+    } catch (e) {
+        logger.error(e as Error, '语音加载失败')
+        // 根据错误信息判断是否因为 OneBot 不支持
+        const msg = (e as Error).message || ''
+        if (msg.includes('不支持') || msg.includes('缺少 file')) {
+            isUnsupported.value = true
+        } else {
+            isError.value = true
+        }
+    } finally {
+        isLoading.value = false
+    }
+}
+
+/**
+ * 切换播放/暂停
+ */
+function togglePlay() {
+    if (isUnsupported.value) return
+
+    if (isError.value) {
+        // 点击重试
+        isError.value = false
+        loaded.value = false
+        audioSrc.value = ''
+        loadVoice()
+        return
+    }
+
+    if (!loaded.value) {
+        loadVoice()
+        return
+    }
+
+    const audio = audioRef.value
+    if (!audio) return
+
+    if (audio.paused) {
+        audio.play().catch((e) => {
+            logger.error(e, '语音播放失败')
+            isError.value = true
+        })
+    } else {
+        audio.pause()
+    }
+}
+
+/**
+ * 音频加载完成
+ */
+function onLoaded() {
+    const audio = audioRef.value
+    if (audio && audio.duration && !duration.value) {
+        duration.value = audio.duration
+    }
+    logger.debug(`音频元数据加载完成: ${duration.value}s`)
+}
+
+/**
+ * 音频加载失败
+ */
+function onError() {
+    logger.error(null, '音频播放错误')
+    isError.value = true
+    isPlaying.value = false
+}
+
+/**
+ * 播放时间更新
+ */
+function onTimeUpdate() {
+    const audio = audioRef.value
+    if (audio) {
+        currentTime.value = audio.currentTime
+    }
+}
+
+/**
+ * 播放结束
+ */
+function onEnded() {
+    isPlaying.value = false
+    currentTime.value = 0
+}
+
+// ============================================================================
+// 生命周期
+// ============================================================================
+
+onMounted(() => {
+    loadVoice()
+})
+
+onBeforeUnmount(() => {
+    // 停止播放
+    const audio = audioRef.value
+    if (audio) {
+        audio.pause()
+        audio.src = ''
+    }
+})
+</script>
+
+<style scoped>
+.voice-msg {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    cursor: pointer;
+    user-select: none;
+    border-radius: 10px;
+    background: var(--color-card-2);
+    transition: all 0.2s ease;
+}
+
+.voice-msg:hover {
+    background: var(--color-card-1);
+    transform: scale(1.01);
+}
+
+.voice-msg.me {
+    background: var(--color-card-1);
+}
+
+.voice-msg.me:hover {
+    background: var(--color-card);
+}
+
+.voice-msg.loading {
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.voice-msg.playing .voice-icon {
+    color: var(--color-main);
+}
+
+/* 播放图标 */
+.voice-icon {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--color-card);
+    color: var(--color-font-2);
+    font-size: 14px;
+    transition: all 0.2s ease;
+}
+
+.voice-msg.me .voice-icon {
+    background: var(--color-card-2);
+    color: var(--color-main);
+}
+
+.voice-msg.playing .voice-icon {
+    background: var(--color-main);
+    color: var(--color-font-r);
+}
+
+/* 进度条区域 */
+.voice-progress {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+.voice-bar-bg {
+    width: 100%;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--color-card-1);
+    overflow: hidden;
+}
+
+.voice-bar-fill {
+    height: 100%;
+    border-radius: 2px;
+    background: var(--color-main);
+    transition: width 0.1s linear;
+}
+
+.voice-duration {
+    font-size: 0.75rem;
+    color: var(--color-font-2);
+    white-space: nowrap;
+}
+
+.voice-unsupported {
+    font-size: 0.75rem;
+    color: var(--color-font-2);
+    opacity: 0.6;
+    font-style: italic;
+}
+
+.voice-msg.me .voice-duration {
+    color: var(--color-font-1);
+}
+</style>

--- a/src/renderer/src/function/utils/recordUtil.ts
+++ b/src/renderer/src/function/utils/recordUtil.ts
@@ -51,12 +51,16 @@ function getAudioDuration(url: string): Promise<number> {
         const done = (val: number) => {
             if (!resolved) {
                 resolved = true
-                audio.remove()
+                audio.removeEventListener('loadedmetadata', onMeta)
+                audio.removeEventListener('error', onErr)
+                audio.src = ''
                 resolve(val)
             }
         }
-        audio.addEventListener('loadedmetadata', () => done(audio.duration || 0))
-        audio.addEventListener('error', () => done(0))
+        const onMeta = () => done(audio.duration || 0)
+        const onErr = () => done(0)
+        audio.addEventListener('loadedmetadata', onMeta)
+        audio.addEventListener('error', onErr)
         setTimeout(() => done(0), 3000)
         audio.src = url
     })
@@ -78,7 +82,7 @@ function getAudioDuration(url: string): Promise<number> {
  * @throws       无法加载时抛出错误
  */
 export async function loadRecord(data: RecordMsgData, msgId?: string): Promise<RecordLoadResult> {
-    const cacheKey = msgId || data.file || ''
+    const cacheKey = msgId || data.file!
 
     // 缓存检查
     const cached = loadCache.get(cacheKey)

--- a/src/renderer/src/function/utils/recordUtil.ts
+++ b/src/renderer/src/function/utils/recordUtil.ts
@@ -1,0 +1,148 @@
+/*
+ * @FileDescription: 语音消息处理工具
+ * @Author: FuQuan233
+ * @Date: 2026/06/04
+ * @Version: 1.0
+ * @Description: 通过 OneBot get_record API 加载语音消息。
+ *   以 out_format=mp3 请求格式转换，响应 base64 数据直接用于播放。
+ */
+
+import { Logger } from '@renderer/function/base'
+import { Connector } from '@renderer/function/connect'
+
+const logger = new Logger()
+
+/** 语音消息原始数据（来自 OneBot record 消息段） */
+export interface RecordMsgData {
+    file?: string
+    url?: string
+    path?: string
+    magic?: boolean
+    duration?: number
+}
+
+/** 语音加载结果 */
+export interface RecordLoadResult {
+    src: string
+    duration: number
+}
+
+/** 加载缓存 */
+const loadCache = new Map<string, RecordLoadResult>()
+
+/**
+ * base64 字符串转 Blob URL
+ */
+function base64ToBlobUrl(base64: string): string {
+    if (base64.startsWith('base64://')) base64 = base64.substring(9)
+    const binary = atob(base64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+    return URL.createObjectURL(new Blob([bytes], { type: 'audio/mpeg' }))
+}
+
+/**
+ * 获取音频时长
+ */
+function getAudioDuration(url: string): Promise<number> {
+    return new Promise((resolve) => {
+        const audio = new Audio()
+        let resolved = false
+        const done = (val: number) => {
+            if (!resolved) {
+                resolved = true
+                audio.remove()
+                resolve(val)
+            }
+        }
+        audio.addEventListener('loadedmetadata', () => done(audio.duration || 0))
+        audio.addEventListener('error', () => done(0))
+        setTimeout(() => done(0), 3000)
+        audio.src = url
+    })
+}
+
+// ============================================================================
+// 公开 API
+// ============================================================================
+
+/**
+ * 加载语音消息为可播放的音频 URL
+ *
+ * 通过 OneBot get_record API (out_format=mp3) 获取语音，
+ * 响应中的 base64 字段直接包含 MP3 数据。
+ *
+ * @param data   语音消息数据
+ * @param msgId  消息 ID（用于缓存键）
+ * @returns      加载结果
+ * @throws       无法加载时抛出错误
+ */
+export async function loadRecord(data: RecordMsgData, msgId?: string): Promise<RecordLoadResult> {
+    const cacheKey = msgId || data.file || ''
+
+    // 缓存检查
+    const cached = loadCache.get(cacheKey)
+    if (cached) return cached
+
+    if (!data.file) {
+        throw new Error('语音消息缺少 file 字段')
+    }
+
+    // 调用 get_record API
+    const raw = await Connector.callApi('get_record', {
+        file: data.file,
+        out_format: 'mp3',
+    })
+
+    if (!raw) throw new Error('get_record API 返回空')
+
+    // result 兼容数组和单个对象
+    const result: any = Array.isArray(raw) ? raw[0] : raw
+
+    if (!result?.base64 || typeof result.base64 !== 'string') {
+        logger.debug('get_record 响应中没有 base64: ' + JSON.stringify(result).substring(0, 200))
+        throw new Error('OneBot 端不支持语音格式转换')
+    }
+
+    const blobUrl = base64ToBlobUrl(result.base64)
+    const duration = data.duration || (await getAudioDuration(blobUrl))
+
+    logger.debug(`语音加载完成: ${duration.toFixed(1)}s`)
+
+    const loadResult: RecordLoadResult = { src: blobUrl, duration }
+    loadCache.set(cacheKey, loadResult)
+    return loadResult
+}
+
+/**
+ * 释放语音资源
+ */
+export function revokeRecord(msgId?: string): void {
+    if (msgId) {
+        const cached = loadCache.get(msgId)
+        if (cached?.src.startsWith('blob:')) URL.revokeObjectURL(cached.src)
+        loadCache.delete(msgId)
+    }
+}
+
+/**
+ * 清除所有缓存
+ */
+export function clearRecordCache(): void {
+    for (const [, r] of loadCache) {
+        if (r.src.startsWith('blob:')) URL.revokeObjectURL(r.src)
+    }
+    loadCache.clear()
+}
+
+/**
+ * 格式化时长显示
+ * @param seconds 秒数
+ * @returns 格式化的时长字符串 (m:ss)
+ */
+export function formatRecordDuration(seconds: number): string {
+    if (!seconds || seconds <= 0) return '0:00'
+    const m = Math.floor(seconds / 60)
+    const s = Math.floor(seconds % 60)
+    return `${m}:${s.toString().padStart(2, '0')}`
+}


### PR DESCRIPTION
## Summary by Sourcery

通过 OneBot 的 `get_record` API 增加对 QQ 语音消息渲染和播放的支持。

新功能：
- 将 `record` 类型消息渲染为带有播放/暂停控件、进度显示和时长格式化的交互式语音气泡。
- 通过将 base64 音频转换为可播放的 URL，并进行缓存，支持加载和播放 OneBot 语音消息数据。
- 在合并/转发消息预览中显示语音消息占位内容。

增强：
- 定义可复用的工具，用于加载、缓存、释放和格式化 OneBot 语音消息音频数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for rendering and playing QQ voice messages via the OneBot get_record API.

New Features:
- Render record-type messages as interactive voice bubbles with play/pause controls, progress display, and duration formatting.
- Support loading and playback of OneBot voice message data by converting base64 audio to playable URLs with caching.
- Display voice message placeholders in merged/forwarded message previews.

Enhancements:
- Define reusable utilities for loading, caching, releasing, and formatting OneBot voice message audio data.

</details>