### PR TITLE
refactor: decouple session display from group notification settings

### DIFF
--- a/src/renderer/src/components/WelPan.vue
+++ b/src/renderer/src/components/WelPan.vue
@@ -160,19 +160,15 @@
                 <div class="opt-item wel-opt-item">
                     <div>
                         <span>{{ $t('会话显示') }}</span>
-                        <span>{{ $t('控制消息页显示最近会话还是全部会话') }}</span>
+                        <span>{{ $t('关闭时仅显示最近会话，开启后显示全部会话') }}</span>
                     </div>
-                    <div class="select-wrapper">
-                        <select v-model="settingsStore.sysConfig.session_display_mode" style="width: 100%;"
-                            name="session_display_mode" title="session_display_mode" @change="save">
-                            <option value="recent">
-                                {{ $t('仅显示最近有消息的会话') }}
-                            </option>
-                            <option value="all">
-                                {{ $t('显示全部会话') }}
-                            </option>
-                        </select>
-                    </div>
+                    <label class="ss-switch">
+                        <input :checked="settingsStore.sysConfig.session_display_mode === 'all'"
+                            type="checkbox" name="session_display_mode" @change="toggleSessionDisplay">
+                        <div>
+                            <div />
+                        </div>
+                    </label>
                 </div>
                 <div class="opt-item wel-opt-item">
                     <div>
@@ -373,7 +369,7 @@
     import { ref } from 'vue'
     import { i18n } from '@renderer/main'
     import languages from '@renderer/assets/l10n/_l10nconfig.json'
-    import { runASWEvent as save } from '@renderer/function/option'
+    import { runAS, runASWEvent as save } from '@renderer/function/option'
     import { openLink, sendIdentifyData } from '@renderer/function/utils/appUtil'
     import { useSettingsStore } from '@renderer/state/settings'
     import { useUIStore } from '@renderer/state/ui'
@@ -417,6 +413,11 @@
 
     function setPage(name: string) {
         show.value = name
+    }
+
+    function toggleSessionDisplay(event: Event) {
+        const sender = event.target as HTMLInputElement
+        runAS('session_display_mode', sender.checked ? 'all' : 'recent')
     }
 </script>
 

--- a/src/renderer/src/components/WelPan.vue
+++ b/src/renderer/src/components/WelPan.vue
@@ -143,7 +143,7 @@
             </div>
             <div>
                 <span>{{ $t('群收纳盒') }}</span>
-                <a>{{ $t('群收纳盒将所有的群消息收进一个单独的群消息列表内并提供实时置顶新消息的功能；你可以关闭它来控制群消息的直接通知选项。') }}</a>
+                <a>{{ $t('群收纳盒将所有的群消息收进一个单独的群消息列表内并提供实时置顶新消息的功能；会话显示和群通知方式可以单独设置。') }}</a>
                 <div class="opt-item wel-opt-item">
                     <div>
                         <span>{{ $t('群收纳盒') }}</span>
@@ -157,7 +157,24 @@
                         </div>
                     </label>
                 </div>
-                <div v-if="!settingsStore.sysConfig.bubble_sort_user" class="opt-item wel-opt-item">
+                <div class="opt-item wel-opt-item">
+                    <div>
+                        <span>{{ $t('会话显示') }}</span>
+                        <span>{{ $t('控制消息页显示最近会话还是全部会话') }}</span>
+                    </div>
+                    <div class="select-wrapper">
+                        <select v-model="settingsStore.sysConfig.session_display_mode" style="width: 100%;"
+                            name="session_display_mode" title="session_display_mode" @change="save">
+                            <option value="recent">
+                                {{ $t('仅显示最近有消息的会话') }}
+                            </option>
+                            <option value="all">
+                                {{ $t('显示全部会话') }}
+                            </option>
+                        </select>
+                    </div>
+                </div>
+                <div class="opt-item wel-opt-item">
                     <div>
                         <span>{{ $t('群消息通知方式') }}</span>
                         <span>{{ $t('重要消息将始终发起应用内通知和系统通知') }}</span>

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -2017,7 +2017,7 @@ function newMsg(_: string, data: any) {
             (!isGroupMessage || groupPolicyAllowsNotice)
         ) {
             logger.add(LogType.DEBUG, '通知判定：', {
-                notShow: id !== showId,
+                notShow: sessionId !== showId,
                 notFocus: !document.hasFocus(),
                 hidden: document.hidden,
                 isImportant: isImportant
@@ -2029,7 +2029,7 @@ function newMsg(_: string, data: any) {
             if (
                 forceGroupSystemNotice ||
                 forceImportantNotice ||
-                id !== showId ||
+                sessionId !== showId ||
                 !document.hasFocus() ||
                 document.hidden
             ) {
@@ -2051,7 +2051,7 @@ function newMsg(_: string, data: any) {
                     title: data.group_name ?? data.sender.nickname,
                     body:
                         data.message_type === 'group' ? data.sender.nickname + ':' + raw : raw,
-                    tag: `${id}/${data.message_id}`,
+                    tag: `${sessionId}/${data.message_id}`,
                     icon:
                         data.message_type === 'group' ? `https://p.qlogo.cn/gh/${id}/${id}/0` : `https://q1.qlogo.cn/g?b=qq&s=0&nk=${id}`,
                     image: undefined as any,

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -23,6 +23,7 @@ import {
     getMsgData,
     parseMsgList,
     getMsgRawTxt,
+    updateBaseOnMsgList,
     updateLastestHistory,
     sendMsgAppendInfo,
 } from '@renderer/function/utils/msgUtil'
@@ -734,13 +735,10 @@ const msgFunctions = {
                         msgPath.message_list.type,
                         msgPath.message_value,
                     )
-                    const raw = getMsgRawTxt(list[0])
-                    const { time } = list[0]
                     // 更新消息列表
                     const onmsg = contactStore.baseOnMsgList.get(Number(id))
                     if (onmsg) {
-                        onmsg.raw_msg = raw
-                        onmsg.time = getViewTime(Number(time))
+                        Object.assign(onmsg, formatMessageData(list[0], Boolean(onmsg.group_id)))
                         contactStore.baseOnMsgList.set(id, onmsg)
                     }
                 }
@@ -1374,6 +1372,9 @@ function saveUser(msg: { [key: string]: any }, type: string) {
             return 0
         })
         contactStore.userList = contactStore.userList.concat(list)
+        if (settingsStore.sysConfig.session_display_mode === 'all') {
+            updateBaseOnMsgList()
+        }
         // 刷新置顶列表
         const info = settingsStore.sysConfig.top_info as {
             [key: string]: number[]
@@ -1970,46 +1971,50 @@ function newMsg(_: string, data: any) {
             }
         }
 
-        // 群收纳箱 ============================================
-        if (settingsStore.sysConfig.bubble_sort_user) {
-            // 刷新群收纳箱列表
-            let getGroup = contactStore.baseOnMsgList.get(Number(id))
-            // ( 如果 是群组消息 && 群组没有开启通知 && 不是置顶的 ) 这种情况下将群消息添加到群收纳盒中
-            if (!getGroup) {
-                const getList = contactStore.userList.filter((item) => {
-                    return item.group_id === id
+        // 会话状态更新 ============================================
+        const isGroupMessage = data.message_type === 'group'
+        const isTempGroupMessage = data.sub_type === 'group'
+        const sessionId = Number(isTempGroupMessage ? sender : id)
+        let session = contactStore.baseOnMsgList.get(sessionId)
+        if (!session) {
+            if (isTempGroupMessage) {
+                session = {
+                    user_id: sender,
+                    nickname: app.config.globalProperties.$t('临时会话'),
+                    remark: data.sender.user_id,
+                    group_id: data.sender.group_id,
+                    group_name: '',
+                } as UserFriendElem & UserGroupElem
+            } else {
+                session = contactStore.userList.find((item) => {
+                    return item.user_id === id || item.group_id === id
                 })
-                getGroup = getList[0]
-            }
-            if (getGroup) {
-                getGroup.message_id = data.message_id
-                const name = data.sender.card && data.sender.card !== '' ? data.sender.card : data.sender.nickname
-                getGroup.raw_msg = name + ': ' + getMsgRawTxt(data)
-                getGroup.raw_msg_base = getMsgRawTxt(data)
-                getGroup.time = getViewTime(Number(data.time))
-                contactStore.baseOnMsgList.set(Number(id), getGroup)
             }
         }
-
-        const get = [...contactStore.baseOnMsgList.keys()].filter((item) => {
-            return (
-                Number(id) === item || Number(info.target_id) === item
-            )
-        })
+        if (session) {
+            Object.assign(session, formatMessageData(data, isGroupMessage))
+            if (sender != loginId && sender != 0 && id !== showId) {
+                if (!session.new_msg) {
+                    session.new_msg = true
+                    contactStore.newMsgCount++
+                }
+            }
+            if (id !== showId) {
+                if (data.atme) { session.highlight = $t('[有人@你]') }
+                if (data.atall) { session.highlight = $t('[@全体]') }
+                if (isImportant) { session.highlight = $t('[特別关心]') }
+            }
+            contactStore.baseOnMsgList.set(sessionId, session)
+        }
 
         // 通知判定 ============================================
-        // eslint-disable-next-line max-len
-        // (发送者不是自己 && (在特别关心列表里 || 发送者不是群组 || 开启了群组通知模式 || 群组 AT
-        //      || 群组 AT 全体 || 群组开启了通知)) 这些情况需要进行新消息处理
+        const groupNoticeType = settingsStore.sysConfig.group_notice_type
+        const groupPolicyAllowsNotice = groupNoticeType !== 'none' ||
+            data.atme || data.atall || isImportant || isGroupNotice
         if (
             sender != loginId &&
             sender != 0 &&
-            (isImportant ||
-                data.message_type !== 'group' ||
-                settingsStore.sysConfig.group_notice_type != 'none' ||
-                data.atme ||
-                data.atall ||
-                isGroupNotice)
+            (!isGroupMessage || groupPolicyAllowsNotice)
         ) {
             logger.add(LogType.DEBUG, '通知判定：', {
                 notShow: id !== showId,
@@ -2018,12 +2023,15 @@ function newMsg(_: string, data: any) {
                 isImportant: isImportant
             })
             // (发送者没有被打开 || 窗口没有焦点 || 窗口被最小化 || 在特别关心列表里) 这些情况需要进行消息通知
+            const forceGroupSystemNotice = isGroupMessage && groupNoticeType === 'all'
+            const forceImportantNotice = isImportant ||
+                (isGroupMessage && (data.atme || data.atall || isGroupNotice))
             if (
-                settingsStore.sysConfig.group_notice_type == 'all' ||
+                forceGroupSystemNotice ||
+                forceImportantNotice ||
                 id !== showId ||
                 !document.hasFocus() ||
-                document.hidden ||
-                isImportant
+                document.hidden
             ) {
                 // 准备消息内容
                 let raw = getMsgRawTxt(data)
@@ -2061,82 +2069,6 @@ function newMsg(_: string, data: any) {
                     new Notify().notify(msgInfo)
                 }
             }
-            // 如果发送者不在消息列表里，将它添加到消息列表里
-            if (get) {
-                // 如果消息子类是 group，那么是临时消息，需要进行特殊处理
-                if (data.sub_type === 'group') {
-                    // 手动创建一个用户信息，因为临时消息的用户不在用户列表里
-                    const user = {
-                        user_id: sender,
-                        // 因为临时消息没有返回昵称
-                        nickname: app.config.globalProperties.$t('临时会话'),
-                        remark: data.sender.user_id,
-                        new_msg: true,
-                        message_id: data.message_id,
-                        raw_msg: data.raw_message,
-                        time: data.time,
-                        group_id: data.sender.group_id,
-                        group_name: '',
-                    } as UserFriendElem & UserGroupElem
-                    contactStore.baseOnMsgList.set(Number(sender), user)
-                } else {
-                    const getList = contactStore.userList.filter((item) => {
-                        return item.user_id === id || item.group_id === id
-                    })
-
-                    const showUser = getList[0]
-                    const formatted = formatMessageData(data, data.message_type === 'group')
-                    Object.assign(showUser, formatted)
-                    contactStore.baseOnMsgList.set(Number(id), showUser)
-                }
-            }
-            if (id !== showId) {
-                const user = contactStore.baseOnMsgList.get(id)
-                if (user) {
-                    if (!user.new_msg) {
-                        user.new_msg = true
-                        contactStore.newMsgCount++
-                    }
-                    contactStore.baseOnMsgList.set(id, user)
-                }
-            }
-        }
-
-
-
-        // 消息列表 ============================================
-        // 刷新消息列表
-        if (!settingsStore.sysConfig.bubble_sort_user && data.message_type === 'group') {
-            const getList = contactStore.userList.filter((item) => {
-                return item.group_id === id
-            })
-            if (getList.length === 1) {
-                const showGroup = getList[0]
-                const formatted = formatMessageData(data, true)
-                Object.assign(showGroup, formatted)
-                contactStore.baseOnMsgList.set(Number(id), showGroup)
-            }
-        }
-        // 刷新消息
-        if (get) {
-            const item = contactStore.baseOnMsgList.get(Number(id))
-            if (item) {
-                item.message_id = data.message_id
-                if (data.message_type === 'group') {
-                    const name =
-                        data.sender.card && data.sender.card !== '' ? data.sender.card : data.sender.nickname
-                    item.raw_msg = name + ': ' + getMsgRawTxt(data)
-                } else {
-                    item.raw_msg = getMsgRawTxt(data)
-                }
-                item.time = getViewTime(Number(data.time))
-                if (id != showId) {
-                    if (data.atme) { item.highlight = $t('[有人@你]') }
-                    if (data.atall) { item.highlight = $t('[@全体]') }
-                    if (isImportant) { item.highlight = $t('[特別关心]') }
-                }
-                contactStore.baseOnMsgList.set(Number(id), item)
-            }
         }
     }
 }
@@ -2165,11 +2097,11 @@ function updateSysInfo(
 // ==============================================================
 
 function formatMessageData(data: any, isGroup: boolean) {
-    const name = data.sender.card && data.sender.card !== '' ? data.sender.card : data.sender.nickname
+    const name = data.sender?.card && data.sender.card !== '' ? data.sender.card : data.sender?.nickname
 
     return {
         message_id: data.message_id,
-        raw_msg: isGroup ? `${name}: ${getMsgRawTxt(data)}` : getMsgRawTxt(data),
+        raw_msg: isGroup && name ? `${name}: ${getMsgRawTxt(data)}` : getMsgRawTxt(data),
         time: getViewTime(Number(data.time)),
         raw_msg_base: getMsgRawTxt(data)
     }

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -1993,13 +1993,13 @@ function newMsg(_: string, data: any) {
         }
         if (session) {
             Object.assign(session, formatMessageData(data, isGroupMessage))
-            if (sender != loginId && sender != 0 && id !== showId) {
+            if (sender != loginId && sender != 0 && sessionId !== showId) {
                 if (!session.new_msg) {
                     session.new_msg = true
                     contactStore.newMsgCount++
                 }
             }
-            if (id !== showId) {
+            if (sessionId !== showId) {
                 if (data.atme) { session.highlight = $t('[有人@你]') }
                 if (data.atall) { session.highlight = $t('[@全体]') }
                 if (isImportant) { session.highlight = $t('[特別关心]') }

--- a/src/renderer/src/function/option.ts
+++ b/src/renderer/src/function/option.ts
@@ -102,6 +102,7 @@ export const optDefault: { [key: string]: any } = {
     // Function
     close_notice: false,
     bubble_sort_user: true,
+    session_display_mode: 'recent' as 'recent' | 'all',
     close_respond: false,
     msg_taill: '',
     quick_send: 'default',
@@ -151,6 +152,7 @@ const configFunction: { [key: string]: (value: any) => void } = {
     opt_always_top: viewAlwaysTop,
     opt_fast_animation: updateFarstAnimation,
     bubble_sort_user: clearGroupAssist,
+    session_display_mode: clearGroupAssist,
     use_favicon_notice: setFaviconNotice,
     custom_css: injectCustomCss,
     opt_ind_message: updateChatPan

--- a/src/renderer/src/function/utils/msgUtil.ts
+++ b/src/renderer/src/function/utils/msgUtil.ts
@@ -608,7 +608,7 @@ export function updateBaseOnMsgList() {
         const timeB = getSessionTime(b)
         if (timeA !== timeB) return timeB - timeA
 
-        return getSessionSortName(a).localeCompare(getSessionSortName(b))
+        return getSessionSortName(b).localeCompare(getSessionSortName(a))
     }
     topList.sort(sortFun)
     normalList.sort(sortFun)
@@ -617,11 +617,14 @@ export function updateBaseOnMsgList() {
     let groupAssistList = [] as any[]
     if (settingsStore.sysConfig.bubble_sort_user) {
         // 将 normalList 进行拆分
-        onMsgList = topList.concat(normalList.filter((item) => {
+        const shouldShowInMainList = (item: UserFriendElem & UserGroupElem) => {
             return item.user_id || item.new_msg || item.highlight
+        }
+        onMsgList = topList.concat(normalList.filter((item) => {
+            return shouldShowInMainList(item)
         }))
         groupAssistList = normalList.filter((item) => {
-            return item.group_id
+            return item.group_id && !shouldShowInMainList(item)
         })
     } else {
         onMsgList = topList.concat(normalList)

--- a/src/renderer/src/function/utils/msgUtil.ts
+++ b/src/renderer/src/function/utils/msgUtil.ts
@@ -553,13 +553,47 @@ export function updateLastestHistory(item: UserFriendElem & UserGroupElem) {
     )
 }
 
+function getSessionId(item: UserFriendElem & UserGroupElem) {
+    return Number(item.user_id ?? item.group_id)
+}
+
+function getSessionTime(item: UserFriendElem & UserGroupElem) {
+    const time = Number(item.time ?? 0)
+    return Number.isFinite(time) ? time : 0
+}
+
+function getSessionSortName(item: UserFriendElem & UserGroupElem) {
+    return item.py_start ?? getShowName(item.group_name ?? item.nickname ?? '', item.remark ?? '')
+}
+
+function getSessionList() {
+    const contactStore = useContactStore()
+    const settingsStore = useSettingsStore()
+    const sessionMap = new Map<number, UserFriendElem & UserGroupElem>()
+
+    if (settingsStore.sysConfig.session_display_mode === 'all') {
+        contactStore.userList.forEach((item) => {
+            const id = getSessionId(item)
+            if (Number.isFinite(id) && id > 0) {
+                sessionMap.set(id, item)
+            }
+        })
+    }
+
+    contactStore.baseOnMsgList.forEach((item, id) => {
+        sessionMap.set(id, item)
+    })
+
+    return [...sessionMap.values()]
+}
+
 /**
  * 刷新消息列表排序
  */
 export function updateBaseOnMsgList() {
     const contactStore = useContactStore()
     const settingsStore = useSettingsStore()
-    const allList = [...contactStore.baseOnMsgList.values()]
+    const allList = getSessionList()
     // 先更具 item.always_top 是不是 true 拆为两个数组
     const topList = allList.filter((item) => item.always_top)
     const normalList = allList.filter((item) => !item.always_top)
@@ -570,13 +604,11 @@ export function updateBaseOnMsgList() {
         a: UserFriendElem & UserGroupElem,
         b: UserFriendElem & UserGroupElem,
     ) => {
-        if (a.time == b.time || a.time == undefined || b.time == undefined) {
-            if (a.py_start == undefined || b.py_start == undefined) {
-                return 0
-            }
-            return b.py_start.charCodeAt(0) - a.py_start.charCodeAt(0)
-        }
-        return b.time - a.time
+        const timeA = getSessionTime(a)
+        const timeB = getSessionTime(b)
+        if (timeA !== timeB) return timeB - timeA
+
+        return getSessionSortName(a).localeCompare(getSessionSortName(b))
     }
     topList.sort(sortFun)
     normalList.sort(sortFun)
@@ -586,11 +618,10 @@ export function updateBaseOnMsgList() {
     if (settingsStore.sysConfig.bubble_sort_user) {
         // 将 normalList 进行拆分
         onMsgList = topList.concat(normalList.filter((item) => {
-            return item.group_id && canGroupNotice(item.group_id) ||
-                item.user_id || item.new_msg || item.highlight
+            return item.user_id || item.new_msg || item.highlight
         }))
         groupAssistList = normalList.filter((item) => {
-            return item.group_id && !canGroupNotice(item.group_id)
+            return item.group_id
         })
     } else {
         onMsgList = topList.concat(normalList)

--- a/src/renderer/src/pages/options/OptFunction.vue
+++ b/src/renderer/src/pages/options/OptFunction.vue
@@ -40,7 +40,26 @@
                     </div>
                 </label>
             </div>
-            <div v-if="!settingsStore.sysConfig.bubble_sort_user" class="opt-item">
+            <div class="opt-item">
+                <div :class="checkDefault('session_display_mode')" />
+                <font-awesome-icon :icon="['fas', 'address-book']" />
+                <div>
+                    <span>{{ $t('会话显示') }}</span>
+                    <span>{{ $t('控制消息页显示最近会话还是全部会话') }}</span>
+                </div>
+                <div class="select-wrapper">
+                    <select v-model="settingsStore.sysConfig.session_display_mode"
+                        name="session_display_mode" title="session_display_mode" @change="save">
+                        <option value="recent">
+                            {{ $t('仅显示最近有消息的会话') }}
+                        </option>
+                        <option value="all">
+                            {{ $t('显示全部会话') }}
+                        </option>
+                    </select>
+                </div>
+            </div>
+            <div class="opt-item">
                 <div :class="checkDefault('group_notice_type')" />
                 <font-awesome-icon :icon="['fas', 'user-group']" />
                 <div>

--- a/src/renderer/src/pages/options/OptFunction.vue
+++ b/src/renderer/src/pages/options/OptFunction.vue
@@ -9,22 +9,7 @@
 <template>
     <div class="opt-page">
         <div class="ss-card">
-            <header>{{ $t('通知选项') }}</header>
-            <div class="opt-item">
-                <div :class="checkDefault('close_notice')" />
-                <font-awesome-icon :icon="['fas', 'volume-xmark']" />
-                <div>
-                    <span>{{ $t('禁用通知') }}</span>
-                    <span>{{ $t('好嘛 …… 不烦你 ……') }}</span>
-                </div>
-                <label class="ss-switch">
-                    <input v-model="settingsStore.sysConfig.close_notice"
-                        type="checkbox" name="close_notice" @change="save">
-                    <div>
-                        <div />
-                    </div>
-                </label>
-            </div>
+            <header>{{ $t('会话选项') }}</header>
             <div class="opt-item">
                 <div :class="checkDefault('bubble_sort_user')" />
                 <font-awesome-icon :icon="['fas', 'box-open']" />
@@ -45,19 +30,33 @@
                 <font-awesome-icon :icon="['fas', 'address-book']" />
                 <div>
                     <span>{{ $t('会话显示') }}</span>
-                    <span>{{ $t('控制消息页显示最近会话还是全部会话') }}</span>
+                    <span>{{ $t('关闭时仅显示最近会话，开启后显示全部会话') }}</span>
                 </div>
-                <div class="select-wrapper">
-                    <select v-model="settingsStore.sysConfig.session_display_mode"
-                        name="session_display_mode" title="session_display_mode" @change="save">
-                        <option value="recent">
-                            {{ $t('仅显示最近有消息的会话') }}
-                        </option>
-                        <option value="all">
-                            {{ $t('显示全部会话') }}
-                        </option>
-                    </select>
+                <label class="ss-switch">
+                    <input :checked="settingsStore.sysConfig.session_display_mode === 'all'"
+                        type="checkbox" name="session_display_mode" @change="toggleSessionDisplay">
+                    <div>
+                        <div />
+                    </div>
+                </label>
+            </div>
+        </div>
+        <div class="ss-card">
+            <header>{{ $t('通知选项') }}</header>
+            <div class="opt-item">
+                <div :class="checkDefault('close_notice')" />
+                <font-awesome-icon :icon="['fas', 'volume-xmark']" />
+                <div>
+                    <span>{{ $t('禁用通知') }}</span>
+                    <span>{{ $t('好嘛 …… 不烦你 ……') }}</span>
                 </div>
+                <label class="ss-switch">
+                    <input v-model="settingsStore.sysConfig.close_notice"
+                        type="checkbox" name="close_notice" @change="save">
+                    <div>
+                        <div />
+                    </div>
+                </label>
             </div>
             <div class="opt-item">
                 <div :class="checkDefault('group_notice_type')" />
@@ -472,6 +471,11 @@
         setTimeout(() => {
             ndv.value = false
         }, 300)
+    }
+
+    function toggleSessionDisplay(event: Event) {
+        const sender = event.target as HTMLInputElement
+        runAS('session_display_mode', sender.checked ? 'all' : 'recent')
     }
 
     function breakLineTip(event: Event) {


### PR DESCRIPTION
- 设置页现在拆成会话选项和通知选项:
  - 会话选项
    - 群收纳盒
    - 会话显示
  - 通知选项
    - 禁用通知
    - 群消息通知方式

- `群消息通知方式` 也不再因为群收纳盒开关而隐藏。

- `群消息通知方式` 现在只负责消息来了以后怎么通知,不再决定一个群是否应该显示在主会话列表里。因为我认为群通知方式不应该会导致会话显示的差异

- 新增 `会话显示` 选项，用来控制主会话列表显示范围.默认仍然是 `仅显示最近会话`，尽量保持原有行为。


- 修改了新消息处理逻辑,先更新会话状态,再单独判断是否需要通知,避免不通知导致会话状态不更新的问题.修正历史消息刷新后的摘要字段,避免群收纳盒入口摘要落后于真实最新消息

- 限定 `group_notice_type === 'all'` 的作用范围.之前 `group_notice_type === 'all'` 可能影响私聊通知行为。现在它只作为群消息通知策略使用，不再改变私聊通知逻辑。

