### PR TITLE
fix: normalize Electron WebSocket URL

### DIFF
--- a/src/electron/function/connector.ts
+++ b/src/electron/function/connector.ts
@@ -17,7 +17,7 @@ export function buildWebSocketUrl(address: string, token?: string) {
     if (token) {
         parsedUrl.searchParams.set('access_token', token)
     }
-    return parsedUrl.toString()
+    return parsedUrl
 }
 
 export class Connector {
@@ -42,12 +42,25 @@ export class Connector {
     }
 
     connect(url: string, token?: string) {
-        const connectionUrl = buildWebSocketUrl(url, token)
-        const displayUrl = new URL(connectionUrl)
-        if (token) {
-            displayUrl.searchParams.delete('access_token')
+        let parsedUrl: URL
+        try {
+            parsedUrl = buildWebSocketUrl(url, token)
+        } catch (e) {
+            this.logger.error('无效的 WebSocket 地址：', e)
+            this.win.webContents.send('onebot:onclose', {
+                code: 1000,
+                message: 'Invalid WebSocket URL',
+                address: url,
+                token: token,
+            })
+            return
         }
-        url = displayUrl.toString()
+
+        const connectionUrl = parsedUrl.toString()
+        if (token) {
+            parsedUrl.searchParams.delete('access_token')
+        }
+        url = parsedUrl.toString()
 
         if (!this.websocket) {
             this.logger.info('正在连接到：', url)

--- a/src/electron/function/connector.ts
+++ b/src/electron/function/connector.ts
@@ -7,6 +7,19 @@ import log4js from 'log4js'
 import { BrowserWindow, ipcMain } from 'electron'
 import { logLevel } from '../index.ts'
 
+export function buildWebSocketUrl(address: string, token?: string) {
+    let url = address.trim()
+    if (!/^wss?:\/\//i.test(url)) {
+        url = 'wss://' + url
+    }
+
+    const parsedUrl = new URL(url)
+    if (token) {
+        parsedUrl.searchParams.set('access_token', token)
+    }
+    return parsedUrl.toString()
+}
+
 export class Connector {
     private logger = log4js.getLogger('connector')
 
@@ -28,19 +41,17 @@ export class Connector {
         this.logger.info('后端连接器已初始化')
     }
 
-    connect(url: string, token: string) {
-        if (url.indexOf('ws://') < 0 && url.indexOf('wss://') < 0) {
-            url = 'wss://' + url
+    connect(url: string, token?: string) {
+        const connectionUrl = buildWebSocketUrl(url, token)
+        const displayUrl = new URL(connectionUrl)
+        if (token) {
+            displayUrl.searchParams.delete('access_token')
         }
-        // 确保 URL 包含路径部分，避免部分服务器因 HTTP 请求路径为空而返回 400
-        const withoutProtocol = url.replace(/^wss?:\/\//, '')
-        if (!withoutProtocol.includes('/')) {
-            url = url + '/'
-        }
+        url = displayUrl.toString()
 
         if (!this.websocket) {
             this.logger.info('正在连接到：', url)
-            this.websocket = new WebSocket(`${url}?access_token=${encodeURIComponent(token)}`)
+            this.websocket = new WebSocket(connectionUrl)
         } else {
             // 如果前端发起了连接请求，说明前端在未连接状态；断开已有连接，重新连接
             // PS：这种情况一般不会发生，大部分情况是因为 debug 模式前端热重载导致的


### PR DESCRIPTION
## 修改内容

- 使用标准 `URL` / `URLSearchParams` 构造 Electron 主进程的 WebSocket 连接地址
- 保留地址中已有的查询参数，并通过 `set` 正确新增或替换 `access_token`
- 密钥为空时不再附加空的认证参数
- 统一补齐根路径，同时避免将 `/` 错误追加到查询字符串之后
- 日志和回传地址不包含通过独立密钥字段传入的 `access_token`

## 修复场景

旧实现始终使用 `${url}?access_token=...` 拼接。当地址已经包含查询参数时，例如：

```text
ws://127.0.0.1:3001/api?foo=bar
```

会生成：

```text
ws://127.0.0.1:3001/api?foo=bar?access_token=token
```

此时 `access_token` 不会作为独立查询参数被服务端解析。本修改会正确生成：

```text
ws://127.0.0.1:3001/api?foo=bar&access_token=token
```

## 范围说明

本 PR 不改变地址缺少协议时的 WS/WSS 缺省选择。相关策略讨论见 #394。

## 验证

- `yarn typecheck`
- `yarn electron-vite build`
- 验证空密钥、已有查询参数、替换已有 token、特殊字符编码等 URL 构造场景

## Summary by Sourcery

规范 Electron WebSocket URL 与令牌处理方式，以用于连接器连接。

Bug Fixes:
- 确保使用标准的 URL 解析来构建 WebSocket URL，在保留现有查询参数的同时正确添加或替换 `access_token`。
- 当 URL 已包含查询参数时，避免追加格式错误的 `access_token` 查询字符串。
- 防止空的 `access_token` 值作为认证参数附加到 WebSocket 连接中。
- 确保日志和展示使用的 URL 不包含 `access_token`，但实际连接使用的 URL 仍然使用它进行认证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize Electron WebSocket URLs and token handling for connector connections.

Bug Fixes:
- Ensure WebSocket URLs are constructed using standard URL parsing, preserving existing query parameters and correctly adding or replacing the access_token.
- Avoid appending malformed access_token query strings when the URL already contains query parameters.
- Prevent empty access_token values from being attached as authentication parameters in WebSocket connections.
- Ensure log and display URLs omit the access_token while the actual connection URL still uses it for authentication.

</details>