### PR TITLE
fix: keep session previews current

### DIFF
--- a/src/renderer/src/components/FriendBody.vue
+++ b/src/renderer/src/components/FriendBody.vue
@@ -21,13 +21,7 @@
             <div>
                 <p>{{ getShowName(data.group_name || data.nickname, data.remark) }}</p>
                 <div style="flex: 1" />
-                <a class="time">{{
-                    data.time !== undefined
-                        ? Intl.DateTimeFormat(trueLang, {
-                            hour: 'numeric',
-                            minute: 'numeric',
-                        }).format(new Date(data.time)) : ''
-                }}</a>
+                <a class="time">{{ formatSessionTime(data.time) }}</a>
             </div>
             <div>
                 <a v-if="data.highlight" class="highlight">
@@ -45,7 +39,7 @@
 </template>
 
 <script setup lang="ts">
-import { getTrueLang } from '@renderer/function/utils/systemUtil'
+import { formatSessionTime } from '@renderer/function/utils/systemUtil'
 import { getShowName } from '@renderer/function/utils/msgUtil'
 
 defineOptions({ name: 'FriendBody' })
@@ -57,5 +51,4 @@ defineProps<{
     from?: string
 }>()
 
-const trueLang = getTrueLang()
 </script>

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -50,6 +50,7 @@ import {
     UserFriendElem,
     UserGroupElem,
     MsgItemElem,
+    type Session,
 } from './elements/information'
 import { NotifyInfo } from './elements/system'
 import { Notify } from './notify'
@@ -70,9 +71,8 @@ import { useQzoneStore } from '@renderer/state/qzone'
 import {
     getSessionId,
     getMissingGroupPreviewSessions,
-    mergeSessionState,
+    mergeEarlySessionContacts,
     resolveIncomingSession,
-    type SessionContact,
 } from './utils/sessionUtil'
 
 const popInfo = new PopInfo()
@@ -89,9 +89,6 @@ if (msgPathAt != undefined) {
 // 其他 tag
 let listLoadTimes = 0
 const logger = new Logger()
-const GROUP_PREVIEW_HYDRATION_INTERVAL_MS = 150
-let groupPreviewHydrationQueue: SessionContact[] = []
-let groupPreviewHydrationTimer: ReturnType<typeof setTimeout> | undefined
 let firstHeartbeatTime = -1
 let heartbeatTime = -1
 const MILLISECONDS_PER_SECOND = 1000
@@ -113,59 +110,69 @@ export function clearLoginWaveTimer() {
     }
 }
 
-function processGroupPreviewHydrationQueue() {
-    if (groupPreviewHydrationTimer || groupPreviewHydrationQueue.length === 0) {
-        return
+const groupPreviewHydrator = (() => {
+    const intervalMs = 150
+    let queue: Session[] = []
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    function stop() {
+        if (timer) clearTimeout(timer)
+        timer = undefined
     }
 
-    const contactStore = useContactStore()
-    const session = groupPreviewHydrationQueue.shift()
-    if (session) {
-        const sessionId = getSessionId(session)
-        if (
-            Number.isFinite(sessionId) &&
-            sessionId > 0 &&
-            !session.time &&
-            !session.raw_msg &&
-            !contactStore.baseOnMsgList.has(sessionId)
-        ) {
-            contactStore.baseOnMsgList.set(sessionId, session)
-            updateLastestHistory(session)
+    function tick() {
+        timer = undefined
+        const contactStore = useContactStore()
+        const session = queue.shift()
+        if (session) {
+            const sessionId = getSessionId(session)
+            if (
+                Number.isFinite(sessionId) &&
+                sessionId > 0 &&
+                !session.time &&
+                !session.raw_msg &&
+                !contactStore.baseOnMsgList.has(sessionId)
+            ) {
+                // userList 与 baseOnMsgList 共享同一个会话对象；历史响应会原地补全预览。
+                contactStore.baseOnMsgList.set(sessionId, session)
+                updateLastestHistory(session)
+            }
+        }
+
+        if (queue.length > 0) {
+            timer = setTimeout(tick, intervalMs)
         }
     }
 
-    groupPreviewHydrationTimer = setTimeout(() => {
-        groupPreviewHydrationTimer = undefined
-        processGroupPreviewHydrationQueue()
-    }, GROUP_PREVIEW_HYDRATION_INTERVAL_MS)
-}
-
-function scheduleMissingGroupPreviewHydration() {
-    const contactStore = useContactStore()
-    const settingsStore = useSettingsStore()
-    if (settingsStore.sysConfig.session_display_mode !== 'all') return
-
-    const queuedIds = new Set(
-        groupPreviewHydrationQueue.map((item) => getSessionId(item)),
-    )
-    getMissingGroupPreviewSessions(
-        contactStore.userList,
-        contactStore.baseOnMsgList,
-    ).forEach((item) => {
-        if (!queuedIds.has(getSessionId(item))) {
-            groupPreviewHydrationQueue.push(item)
-        }
-    })
-    processGroupPreviewHydrationQueue()
-}
-
-function clearGroupPreviewHydrationQueue() {
-    if (groupPreviewHydrationTimer) {
-        clearTimeout(groupPreviewHydrationTimer)
-        groupPreviewHydrationTimer = undefined
+    function start() {
+        if (!timer && queue.length > 0) tick()
     }
-    groupPreviewHydrationQueue = []
-}
+
+    return {
+        scheduleMissingSessions() {
+            const contactStore = useContactStore()
+            const settingsStore = useSettingsStore()
+            if (settingsStore.sysConfig.session_display_mode !== 'all') return
+
+            const queuedIds = new Set(queue.map((item) => getSessionId(item)))
+            getMissingGroupPreviewSessions(
+                contactStore.userList,
+                contactStore.baseOnMsgList,
+            ).forEach((item) => {
+                const sessionId = getSessionId(item)
+                if (!queuedIds.has(sessionId)) {
+                    queue.push(item)
+                    queuedIds.add(sessionId)
+                }
+            })
+            start()
+        },
+        reset() {
+            stop()
+            queue = []
+        },
+    }
+})()
 
 function resolveContactPinyinName(item: UserFriendElem | UserGroupElem) {
     if ((item as UserFriendElem).group_id) {
@@ -1373,7 +1380,7 @@ const msgFunctions = {
             })
         }
         // “显示全部会话”会包含 recent_contact 之外的群；限流补取这些群的最后一条历史。
-        scheduleMissingGroupPreviewHydration()
+        groupPreviewHydrator.scheduleMissingSessions()
     },
 
     /**
@@ -1597,18 +1604,15 @@ function saveUser(msg: { [key: string]: any }, type: string) {
         }
         sortContactListByPinyin(list)
         // 实时消息可能比联系人列表更早到达；用真实联系人资料接管临时会话，保留预览状态。
-        list.forEach((item) => {
-            const sessionId = getSessionId(item)
-            const currentSession = contactStore.baseOnMsgList.get(sessionId)
-            if (currentSession && currentSession !== item) {
-                contactStore.baseOnMsgList.set(
-                    sessionId,
-                    mergeSessionState(item, currentSession),
-                )
-            }
-        })
+        const didMergeEarlySessions = mergeEarlySessionContacts(
+            list,
+            contactStore.baseOnMsgList,
+        )
         contactStore.userList = contactStore.userList.concat(list)
-        if (settingsStore.sysConfig.session_display_mode === 'all') {
+        if (
+            settingsStore.sysConfig.session_display_mode === 'all' ||
+            didMergeEarlySessions
+        ) {
             updateBaseOnMsgList()
         }
         // 刷新置顶列表
@@ -2417,7 +2421,7 @@ export function resetRimtime(resetAll = false) {
     firstHeartbeatTime = -1
     heartbeatTime = -1
     clearMetaEventWatchdog()
-    clearGroupPreviewHydrationQueue()
+    groupPreviewHydrator.reset()
     if (resetAll) {
         // Reset auth store
         const authStore = useAuthStore()

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -67,6 +67,11 @@ import { useStickerStore } from '@renderer/state/sticker'
 import { useUIStore } from '@renderer/state/ui'
 import { useSettingsStore } from '@renderer/state/settings'
 import { useQzoneStore } from '@renderer/state/qzone'
+import {
+    getSessionId,
+    mergeSessionState,
+    resolveIncomingSession,
+} from './utils/sessionUtil'
 
 const popInfo = new PopInfo()
 // eslint-disable-next-line
@@ -1530,6 +1535,17 @@ function saveUser(msg: { [key: string]: any }, type: string) {
             hydrateContactPinyinLater(list)
         }
         sortContactListByPinyin(list)
+        // 实时消息可能比联系人列表更早到达；用真实联系人资料接管临时会话，保留预览状态。
+        list.forEach((item) => {
+            const sessionId = getSessionId(item)
+            const currentSession = contactStore.baseOnMsgList.get(sessionId)
+            if (currentSession && currentSession !== item) {
+                contactStore.baseOnMsgList.set(
+                    sessionId,
+                    mergeSessionState(item, currentSession),
+                )
+            }
+        })
         contactStore.userList = contactStore.userList.concat(list)
         if (settingsStore.sysConfig.session_display_mode === 'all') {
             updateBaseOnMsgList()
@@ -2208,9 +2224,12 @@ function newMsg(_: string, data: any) {
                     group_name: '',
                 } as UserFriendElem & UserGroupElem
             } else {
-                session = contactStore.userList.find((item) => {
-                    return item.user_id === id || item.group_id === id
-                })
+                session = resolveIncomingSession(
+                    contactStore.userList,
+                    sessionId,
+                    isGroupMessage,
+                    data.sender?.nickname,
+                )
             }
         }
         if (session) {

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -871,9 +871,10 @@ const msgFunctions = {
                     )
                     // 更新消息列表
                     const onmsg = contactStore.baseOnMsgList.get(Number(id))
-                    if (onmsg) {
+                    if (onmsg && list[0]) {
                         Object.assign(onmsg, formatMessageData(list[0], Boolean(onmsg.group_id)))
                         contactStore.baseOnMsgList.set(id, onmsg)
+                        updateBaseOnMsgList()
                     }
                 }
             } catch (e) {
@@ -1691,7 +1692,7 @@ async function saveMsg(msg: any, append = undefined as undefined | string) {
         chatStore.messageList.forEach((item) => {
             sendMsgAppendInfo(item)
         })
-        // 将消息列表的最后一条 raw_message 保存到用户列表中
+        // 将最新消息同步到会话列表；通过会话 Map 更新以触发 shallowRef 列表刷新。
         const lastMsg =
             chatStore.messageList[chatStore.messageList.length - 1]
         if (lastMsg) {
@@ -1701,14 +1702,17 @@ async function saveMsg(msg: any, append = undefined as undefined | string) {
                     item.user_id == chatStore.chatInfo.show.id
                 )
             })
-            if (user) {
-                if (chatStore.chatInfo.show.type == 'group') {
-                    user.raw_msg =
-                        lastMsg.sender.nickname + ': ' + getMsgRawTxt(lastMsg)
-                } else {
-                    user.raw_msg = getMsgRawTxt(lastMsg)
-                }
-                user.time = getViewTime(Number(lastMsg.time))
+            const sessionId = Number(chatStore.chatInfo.show.id)
+            const session = contactStore.baseOnMsgList.get(sessionId) ?? user
+            if (session) {
+                const preview = formatMessageData(
+                    lastMsg,
+                    chatStore.chatInfo.show.type == 'group',
+                )
+                if (user) Object.assign(user, preview)
+                Object.assign(session, preview)
+                contactStore.baseOnMsgList.set(sessionId, session)
+                updateBaseOnMsgList()
             }
         }
 
@@ -2228,6 +2232,7 @@ function newMsg(_: string, data: any) {
                 if (isImportant) { session.highlight = $t('[特別关心]') }
             }
             contactStore.baseOnMsgList.set(sessionId, session)
+            updateBaseOnMsgList()
         }
 
         // 通知判定 ============================================

--- a/src/renderer/src/function/msg.ts
+++ b/src/renderer/src/function/msg.ts
@@ -69,8 +69,10 @@ import { useSettingsStore } from '@renderer/state/settings'
 import { useQzoneStore } from '@renderer/state/qzone'
 import {
     getSessionId,
+    getMissingGroupPreviewSessions,
     mergeSessionState,
     resolveIncomingSession,
+    type SessionContact,
 } from './utils/sessionUtil'
 
 const popInfo = new PopInfo()
@@ -87,6 +89,9 @@ if (msgPathAt != undefined) {
 // 其他 tag
 let listLoadTimes = 0
 const logger = new Logger()
+const GROUP_PREVIEW_HYDRATION_INTERVAL_MS = 150
+let groupPreviewHydrationQueue: SessionContact[] = []
+let groupPreviewHydrationTimer: ReturnType<typeof setTimeout> | undefined
 let firstHeartbeatTime = -1
 let heartbeatTime = -1
 const MILLISECONDS_PER_SECOND = 1000
@@ -106,6 +111,60 @@ export function clearLoginWaveTimer() {
         clearInterval(loginWaveTimer)
         loginWaveTimer = null
     }
+}
+
+function processGroupPreviewHydrationQueue() {
+    if (groupPreviewHydrationTimer || groupPreviewHydrationQueue.length === 0) {
+        return
+    }
+
+    const contactStore = useContactStore()
+    const session = groupPreviewHydrationQueue.shift()
+    if (session) {
+        const sessionId = getSessionId(session)
+        if (
+            Number.isFinite(sessionId) &&
+            sessionId > 0 &&
+            !session.time &&
+            !session.raw_msg &&
+            !contactStore.baseOnMsgList.has(sessionId)
+        ) {
+            contactStore.baseOnMsgList.set(sessionId, session)
+            updateLastestHistory(session)
+        }
+    }
+
+    groupPreviewHydrationTimer = setTimeout(() => {
+        groupPreviewHydrationTimer = undefined
+        processGroupPreviewHydrationQueue()
+    }, GROUP_PREVIEW_HYDRATION_INTERVAL_MS)
+}
+
+function scheduleMissingGroupPreviewHydration() {
+    const contactStore = useContactStore()
+    const settingsStore = useSettingsStore()
+    if (settingsStore.sysConfig.session_display_mode !== 'all') return
+
+    const queuedIds = new Set(
+        groupPreviewHydrationQueue.map((item) => getSessionId(item)),
+    )
+    getMissingGroupPreviewSessions(
+        contactStore.userList,
+        contactStore.baseOnMsgList,
+    ).forEach((item) => {
+        if (!queuedIds.has(getSessionId(item))) {
+            groupPreviewHydrationQueue.push(item)
+        }
+    })
+    processGroupPreviewHydrationQueue()
+}
+
+function clearGroupPreviewHydrationQueue() {
+    if (groupPreviewHydrationTimer) {
+        clearTimeout(groupPreviewHydrationTimer)
+        groupPreviewHydrationTimer = undefined
+    }
+    groupPreviewHydrationQueue = []
 }
 
 function resolveContactPinyinName(item: UserFriendElem | UserGroupElem) {
@@ -1313,6 +1372,8 @@ const msgFunctions = {
                 }
             })
         }
+        // “显示全部会话”会包含 recent_contact 之外的群；限流补取这些群的最后一条历史。
+        scheduleMissingGroupPreviewHydration()
     },
 
     /**
@@ -2356,6 +2417,7 @@ export function resetRimtime(resetAll = false) {
     firstHeartbeatTime = -1
     heartbeatTime = -1
     clearMetaEventWatchdog()
+    clearGroupPreviewHydrationQueue()
     if (resetAll) {
         // Reset auth store
         const authStore = useAuthStore()

--- a/src/renderer/src/function/utils/msgUtil.ts
+++ b/src/renderer/src/function/utils/msgUtil.ts
@@ -18,6 +18,10 @@ import { useContactStore } from '@renderer/state/contact'
 import { useUIStore } from '@renderer/state/ui'
 import { useAuthStore } from '@renderer/state/auth'
 import { useChatStore } from '@renderer/state/chat'
+import {
+    findSessionContact,
+    getSessionId,
+} from './sessionUtil'
 
 const logger = new Logger()
 
@@ -480,9 +484,7 @@ export function sendMsgRaw(
         // 发送方不一定会上报自身消息事件，先用预发送消息同步会话预览。
         const sessionId = Number(String(id).split('/')[0])
         const session = contactStore.baseOnMsgList.get(sessionId) ??
-            contactStore.userList.find((item) => {
-                return item.user_id === sessionId || item.group_id === sessionId
-            })
+            findSessionContact(contactStore.userList, sessionId)
         if (session) {
             const raw = getMsgRawTxt(showMsg)
             const senderName = authStore.loginInfo.nickname
@@ -580,10 +582,6 @@ export function updateLastestHistory(item: UserFriendElem & UserGroupElem) {
         },
         'getChatHistoryOnMsg_' + id,
     )
-}
-
-function getSessionId(item: UserFriendElem & UserGroupElem) {
-    return Number(item.user_id ?? item.group_id)
 }
 
 function getSessionTime(item: UserFriendElem & UserGroupElem) {

--- a/src/renderer/src/function/utils/msgUtil.ts
+++ b/src/renderer/src/function/utils/msgUtil.ts
@@ -432,6 +432,7 @@ export function sendMsgRaw(
 ) {
     const chatStore = useChatStore()
     const authStore = useAuthStore()
+    const contactStore = useContactStore()
     const uiStore = useUIStore()
     // 如果消息为空则不发送
     if (msg == undefined || msg == '' || (Array.isArray(msg) && msg.length == 0)) {
@@ -475,6 +476,25 @@ export function sendMsgRaw(
             showMsg.user_id = chatStore.chatInfo.show.id
         }
         chatStore.messageList = chatStore.messageList.concat([showMsg])
+
+        // 发送方不一定会上报自身消息事件，先用预发送消息同步会话预览。
+        const sessionId = Number(String(id).split('/')[0])
+        const session = contactStore.baseOnMsgList.get(sessionId) ??
+            contactStore.userList.find((item) => {
+                return item.user_id === sessionId || item.group_id === sessionId
+            })
+        if (session) {
+            const raw = getMsgRawTxt(showMsg)
+            const senderName = authStore.loginInfo.nickname
+            Object.assign(session, {
+                message_id: showMsg.message_id,
+                raw_msg: type === 'group' && senderName ? `${senderName}: ${raw}` : raw,
+                raw_msg_base: raw,
+                time: showMsg.time * 1000,
+            })
+            contactStore.baseOnMsgList.set(sessionId, session)
+            updateBaseOnMsgList()
+        }
     }
     // 检查消息体是否需要处理
     if (uiStore.msgType == BotMsgType.Array) {

--- a/src/renderer/src/function/utils/sessionUtil.ts
+++ b/src/renderer/src/function/utils/sessionUtil.ts
@@ -1,16 +1,11 @@
-import type {
-    UserFriendElem,
-    UserGroupElem,
-} from '../elements/information'
+import type { Session } from '../elements/information'
 
-export type SessionContact = UserFriendElem & UserGroupElem
-
-export function getSessionId(item: SessionContact) {
+export function getSessionId(item: Session) {
     return Number(item.user_id ?? item.group_id)
 }
 
 export function findSessionContact(
-    contacts: SessionContact[],
+    contacts: Session[],
     sessionId: number,
 ) {
     return contacts.find((item) => {
@@ -19,8 +14,8 @@ export function findSessionContact(
 }
 
 export function getMissingGroupPreviewSessions(
-    contacts: SessionContact[],
-    knownSessions: ReadonlyMap<number, SessionContact>,
+    contacts: Session[],
+    knownSessions: ReadonlyMap<number, Session>,
 ) {
     return contacts.filter((item) => {
         const sessionId = getSessionId(item)
@@ -34,7 +29,7 @@ export function getMissingGroupPreviewSessions(
 }
 
 export function resolveIncomingSession(
-    contacts: SessionContact[],
+    contacts: Session[],
     sessionId: number,
     isGroup: boolean,
     senderName?: string,
@@ -47,13 +42,13 @@ export function resolveIncomingSession(
         return {
             group_id: sessionId,
             group_name: String(sessionId),
-        } as SessionContact
+        } as Session
     }
     return {
         user_id: sessionId,
         nickname: senderName || String(sessionId),
         remark: '',
-    } as SessionContact
+    } as Session
 }
 
 const SESSION_STATE_KEYS = [
@@ -66,16 +61,48 @@ const SESSION_STATE_KEYS = [
     'highlight',
 ] as const
 
-export function mergeSessionState(
-    contact: SessionContact,
-    currentSession: SessionContact,
+type SessionStateKey = (typeof SESSION_STATE_KEYS)[number]
+
+function copyDefinedSessionState<K extends SessionStateKey>(
+    contact: Session,
+    currentSession: Session,
+    key: K,
 ) {
-    const contactRecord = contact as unknown as Record<string, unknown>
-    const sessionRecord = currentSession as unknown as Record<string, unknown>
-    SESSION_STATE_KEYS.forEach((key) => {
-        if (sessionRecord[key] !== undefined) {
-            contactRecord[key] = sessionRecord[key]
+    const value = currentSession[key]
+    if (value !== undefined) {
+        contact[key] = value
+    }
+}
+
+export function mergeSessionState(
+    contact: Session,
+    currentSession: Session,
+) {
+    SESSION_STATE_KEYS.forEach((key) =>
+        copyDefinedSessionState(contact, currentSession, key),
+    )
+    return contact
+}
+
+/**
+ * 让真实联系人接管消息早到时创建的占位会话。
+ * 返回 true 表示 Map 中的对象引用已替换，调用方需要重建派生会话列表。
+ */
+export function mergeEarlySessionContacts(
+    contacts: Session[],
+    sessions: Map<number, Session>,
+) {
+    let didMerge = false
+    contacts.forEach((contact) => {
+        const sessionId = getSessionId(contact)
+        const currentSession = sessions.get(sessionId)
+        if (currentSession && currentSession !== contact) {
+            sessions.set(
+                sessionId,
+                mergeSessionState(contact, currentSession),
+            )
+            didMerge = true
         }
     })
-    return contact
+    return didMerge
 }

--- a/src/renderer/src/function/utils/sessionUtil.ts
+++ b/src/renderer/src/function/utils/sessionUtil.ts
@@ -18,6 +18,21 @@ export function findSessionContact(
     })
 }
 
+export function getMissingGroupPreviewSessions(
+    contacts: SessionContact[],
+    knownSessions: ReadonlyMap<number, SessionContact>,
+) {
+    return contacts.filter((item) => {
+        const sessionId = getSessionId(item)
+        return Boolean(item.group_id) &&
+            Number.isFinite(sessionId) &&
+            sessionId > 0 &&
+            !item.time &&
+            !item.raw_msg &&
+            !knownSessions.has(sessionId)
+    })
+}
+
 export function resolveIncomingSession(
     contacts: SessionContact[],
     sessionId: number,

--- a/src/renderer/src/function/utils/sessionUtil.ts
+++ b/src/renderer/src/function/utils/sessionUtil.ts
@@ -1,0 +1,66 @@
+import type {
+    UserFriendElem,
+    UserGroupElem,
+} from '../elements/information'
+
+export type SessionContact = UserFriendElem & UserGroupElem
+
+export function getSessionId(item: SessionContact) {
+    return Number(item.user_id ?? item.group_id)
+}
+
+export function findSessionContact(
+    contacts: SessionContact[],
+    sessionId: number,
+) {
+    return contacts.find((item) => {
+        return getSessionId(item) === sessionId
+    })
+}
+
+export function resolveIncomingSession(
+    contacts: SessionContact[],
+    sessionId: number,
+    isGroup: boolean,
+    senderName?: string,
+) {
+    const contact = findSessionContact(contacts, sessionId)
+    if (contact) return contact
+
+    // 消息事件可能早于好友/群列表返回。先保留会话动态状态，列表加载后再合并真实资料。
+    if (isGroup) {
+        return {
+            group_id: sessionId,
+            group_name: String(sessionId),
+        } as SessionContact
+    }
+    return {
+        user_id: sessionId,
+        nickname: senderName || String(sessionId),
+        remark: '',
+    } as SessionContact
+}
+
+const SESSION_STATE_KEYS = [
+    'new_msg',
+    'raw_msg',
+    'raw_msg_base',
+    'time',
+    'always_top',
+    'message_id',
+    'highlight',
+] as const
+
+export function mergeSessionState(
+    contact: SessionContact,
+    currentSession: SessionContact,
+) {
+    const contactRecord = contact as unknown as Record<string, unknown>
+    const sessionRecord = currentSession as unknown as Record<string, unknown>
+    SESSION_STATE_KEYS.forEach((key) => {
+        if (sessionRecord[key] !== undefined) {
+            contactRecord[key] = sessionRecord[key]
+        }
+    })
+    return contact
+}

--- a/src/renderer/src/function/utils/systemUtil.ts
+++ b/src/renderer/src/function/utils/systemUtil.ts
@@ -525,6 +525,53 @@ export function getViewTime(time: number) {
 }
 
 /**
+ * 格式化会话列表中的最新消息时间。
+ * 今天显示时间，本周显示星期和时间，更早的消息显示日期。
+ */
+export function formatSessionTime(time: number | undefined, now = new Date()) {
+    if (time === undefined) return ''
+
+    const viewTime = getViewTime(Number(time))
+    const date = new Date(viewTime)
+    if (!Number.isFinite(viewTime) || Number.isNaN(date.getTime())) return ''
+
+    const startOfToday = new Date(now)
+    startOfToday.setHours(0, 0, 0, 0)
+    const startOfTomorrow = new Date(startOfToday)
+    startOfTomorrow.setDate(startOfTomorrow.getDate() + 1)
+
+    const startOfWeek = new Date(startOfToday)
+    const daysSinceMonday = (startOfWeek.getDay() + 6) % 7
+    startOfWeek.setDate(startOfWeek.getDate() - daysSinceMonday)
+    const startOfNextWeek = new Date(startOfWeek)
+    startOfNextWeek.setDate(startOfNextWeek.getDate() + 7)
+
+    let config: Intl.DateTimeFormatOptions
+    if (date >= startOfToday && date < startOfTomorrow) {
+        config = {
+            hour: 'numeric',
+            minute: 'numeric',
+        }
+    } else if (date >= startOfWeek && date < startOfNextWeek) {
+        config = {
+            weekday: 'short',
+            hour: 'numeric',
+            minute: 'numeric',
+        }
+    } else {
+        config = {
+            month: 'short',
+            day: 'numeric',
+        }
+        if (date.getFullYear() !== now.getFullYear()) {
+            config.year = 'numeric'
+        }
+    }
+
+    return Intl.DateTimeFormat(getTrueLang(), config).format(date)
+}
+
+/**
  * 获取时间的配置
  * @param date
  * @returns

--- a/src/renderer/src/function/utils/systemUtil.ts
+++ b/src/renderer/src/function/utils/systemUtil.ts
@@ -512,9 +512,10 @@ export function randomChoice<T>(...args: T[]): T{
 }
 
 /**
- * 获取显示的时间，由于获得的时间戳可能是秒级的，也可能是毫秒级的，所以需要判断
- * @param time
- * @param i0n
+ * 将秒级或毫秒级 Unix 时间戳统一为毫秒。
+ * 已是毫秒的输入会原样返回，因此允许在显示边界重复规范化。
+ * @param time 秒级或毫秒级 Unix 时间戳
+ * @returns 毫秒级 Unix 时间戳
  */
 export function getViewTime(time: number) {
     if (time.toString().length === 10) {
@@ -525,7 +526,8 @@ export function getViewTime(time: number) {
 }
 
 /**
- * 格式化会话列表中的最新消息时间。
+ * 格式化会话列表中的最新消息时间。输入可为秒或毫秒，内部仅规范化一次；
+ * getViewTime 对已经由消息处理流程保存的毫秒值保持不变。
  * 今天显示时间，本周显示星期和时间，更早的消息显示日期。
  */
 export function formatSessionTime(time: number | undefined, now = new Date()) {


### PR DESCRIPTION
## What changed

- refresh session preview text and ordering after local sends, incoming messages, and history responses
- format session timestamps as time today, weekday plus time in the current week, and date for older messages
- normalize string/number session IDs and preserve incoming events that arrive before contacts are loaded
- hydrate missing group previews in `all` display mode with a rate-limited, deduplicated queue

## Root cause

The session UI is derived from a shallow list while several message paths mutated raw contact objects without rebuilding that list. Incoming OneBot IDs could also differ in runtime type from contact IDs, causing unopened groups to miss the realtime lookup. Finally, `all` mode renders every contact but startup history hydration only covered `recent_contact`, so groups outside that response stayed blank until the chat was opened.

## Impact

Conversation previews and timestamps now update without opening the conversation first. Groups that are blocked or genuinely have no available messages can still remain blank.

## Validation

- targeted Node regression harnesses for session resolution and missing group preview selection
- targeted ESLint
- `yarn typecheck`
- `yarn build`
- deployed integration build and verified live in Chrome: 20/24 groups populated without being opened; the remaining four were confirmed as one no-message muted group and three blocked groups

## Summary by Sourcery

确保会话列表中的预览和时间戳在已发送消息、接收中的消息以及历史消息回灌（hydrated history）之间保持最新且一致。

New Features:
- 为会话时间戳添加格式：今天显示具体时间、本周显示“星期几 + 时间”、更早的消息显示日期。
- 引入一个工具模块，用于在不同消息事件之间解析和跟踪会话联系人。

Bug Fixes:
- 在本地发送消息时，通过更新会话映射并刷新派生列表，使会话预览保持同步。
- 即使在联系人 ID 的运行时类型不同，或联系人列表尚未加载完成的情况下，也能为接收消息正确解析会话。
- 在“显示所有会话”模式下，为缺失的群聊会话预览进行回灌，使尚未打开的群组也能显示最新消息。

Enhancements:
- 优化会话状态处理逻辑，将临时会话数据合并到真实联系人中，同时保持预览状态不丢失。
- 对缺失群聊预览的后台回灌进行限流和去重，避免重复工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure session list previews and timestamps stay up to date and consistent across sent, incoming, and hydrated history messages.

New Features:
- Add formatting for session timestamps to show time for today, weekday plus time for this week, and date for older messages.
- Introduce a utility module for resolving and tracking session contacts across message events.

Bug Fixes:
- Keep session previews in sync when sending messages locally by updating the session map and refreshing the derived list.
- Resolve sessions for incoming messages even when contact IDs differ in runtime type or arrive before the contact list is loaded.
- Hydrate missing group conversation previews in "show all sessions" mode so unopened groups can display their latest message.

Enhancements:
- Refine session state handling by merging temporary session data into real contacts while preserving preview state.
- Rate-limit and deduplicate background hydration of missing group previews to avoid redundant work.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保会话列表中的预览和时间戳在已发送消息、接收中的消息以及历史消息回灌（hydrated history）之间保持最新且一致。

New Features:
- 为会话时间戳添加格式：今天显示具体时间、本周显示“星期几 + 时间”、更早的消息显示日期。
- 引入一个工具模块，用于在不同消息事件之间解析和跟踪会话联系人。

Bug Fixes:
- 在本地发送消息时，通过更新会话映射并刷新派生列表，使会话预览保持同步。
- 即使在联系人 ID 的运行时类型不同，或联系人列表尚未加载完成的情况下，也能为接收消息正确解析会话。
- 在“显示所有会话”模式下，为缺失的群聊会话预览进行回灌，使尚未打开的群组也能显示最新消息。

Enhancements:
- 优化会话状态处理逻辑，将临时会话数据合并到真实联系人中，同时保持预览状态不丢失。
- 对缺失群聊预览的后台回灌进行限流和去重，避免重复工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure session list previews and timestamps stay up to date and consistent across sent, incoming, and hydrated history messages.

New Features:
- Add formatting for session timestamps to show time for today, weekday plus time for this week, and date for older messages.
- Introduce a utility module for resolving and tracking session contacts across message events.

Bug Fixes:
- Keep session previews in sync when sending messages locally by updating the session map and refreshing the derived list.
- Resolve sessions for incoming messages even when contact IDs differ in runtime type or arrive before the contact list is loaded.
- Hydrate missing group conversation previews in "show all sessions" mode so unopened groups can display their latest message.

Enhancements:
- Refine session state handling by merging temporary session data into real contacts while preserving preview state.
- Rate-limit and deduplicate background hydration of missing group previews to avoid redundant work.

</details>

</details>